### PR TITLE
Release v0.1.0 — Wiener Linien departure monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,11 @@ If you build a Lovelace card or other user-facing UI on top of this integration,
 ## License
 
 MIT — see [LICENSE](LICENSE). The integration code is MIT; the Wiener Linien data flowing through it is CC BY 4.0.
+
+## Disclaimer
+
+This integration is not affiliated with or endorsed by Wiener Linien GmbH & Co KG. All departure and stop data is provided by the [Wiener Linien OGD real-time API](https://www.wienerlinien.at/open-data) and published under the Creative Commons Attribution (CC BY 4.0) license. The developer assumes no liability for the accuracy, completeness, or timeliness of the displayed departures, including delays, cancellations, or disruptions. Use at your own risk.
+
+---
+
+Diese Integration steht in keiner Verbindung zur Wiener Linien GmbH & Co KG und wird von dieser nicht unterstützt. Alle Abfahrts- und Haltestellendaten stammen von der [Wiener Linien OGD Echtzeit-API](https://www.wienerlinien.at/open-data) und werden unter der Creative-Commons-Lizenz Namensnennung 4.0 (CC BY 4.0) veröffentlicht. Für die Richtigkeit, Vollständigkeit und Aktualität der angezeigten Abfahrten — einschließlich Verspätungen, Ausfällen oder Störungen — wird keine Haftung übernommen. Nutzung auf eigene Verantwortung.

--- a/custom_components/wiener_linien_austria/config_flow.py
+++ b/custom_components/wiener_linien_austria/config_flow.py
@@ -55,6 +55,14 @@ from .static import Station, async_load_catalogue
 
 _LOGGER = logging.getLogger(__name__)
 
+# SelectOptionDict labels bypass HA's selector translation system, so we
+# pick the right locale at runtime. English is the fallback for anything
+# not explicitly listed.
+_SEARCH_AGAIN_LABELS: dict[str, str] = {
+    "en": "↩ Search again",
+    "de": "↩ Erneut suchen",
+}
+
 
 def _line_key(line: str, direction: str, towards: str) -> str:
     """Stable identifier for a (line, direction, towards) triple.
@@ -207,8 +215,12 @@ class WienerLinienAustriaConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             for s in self._matches
         ]
+        lang = self.hass.config.language
+        search_again_label = _SEARCH_AGAIN_LABELS.get(
+            lang, _SEARCH_AGAIN_LABELS["en"]
+        )
         options.append(
-            SelectOptionDict(value="__search_again__", label="↩ Search again")
+            SelectOptionDict(value="__search_again__", label=search_again_label)
         )
 
         return self.async_show_form(


### PR DESCRIPTION
## Summary

First public release. Real-time Wiener Linien departure monitor for Home Assistant — built Platinum from day one, no API key, no YAML editing, no manual RBL lookups.

Ships the three-step config flow (search → pick stop → pick lines with a live `/monitor` probe), a single sensor per stop whose state is the next countdown and whose attributes carry the full board, CC BY 4.0 attribution on every surface, bilingual UI + legal disclaimer, and a test suite that actually exercises the code (46/46 passing, mypy --strict clean, ruff clean).

## What's included

**Integration core**
- `__init__.py` — config entry lifecycle, explicit `dr.async_get_or_create` device registration, weekly static-catalogue refresh with `cancel_on_shutdown=True`, `async_migrate_entry` stub for future schema changes.
- `coordinator.py` — `DataUpdateCoordinator[MonitorData]` hitting `/monitor?stopId=<RBL>` once per refresh, 30 s per-entry floor, **15 s domain-wide cooldown** across all entries, exception-translations for 6 distinct error keys, Repairs issue on error code 316 (rate-limit) with automatic recovery.
- `config_flow.py` — three-step flow (`user` → `select_stop` → `select_lines`), live `/monitor` probe during setup (also satisfies `test-before-configure`), `async_step_reconfigure`, options flow for scan interval only. "Search again" option localised to DE/EN based on `hass.config.language`.
- `sensor.py` — `SensorDeviceClass.DURATION` in minutes, unique_id format `{entry_id}_stop`, attribution + `departures` + `departures_by_line` + `next_by_line` in attributes.
- `static.py` — `Store`-backed catalogue loader, fetches `haltestellen.csv` + `haltepunkte.csv` once per week, DIVA → RBL resolution, case-insensitive prefix-preferring search.
- `diagnostics.py` — attribution, RBL list, last error code, server time, exact departure count.
- `strings.json` + `translations/{en,de}.json` + `icons.json` — fully populated for Gold's `entity-translations`, `exception-translations`, `icon-translations` rules.

**Quality gates (all `done` in `quality_scale.yaml`)**
- Bronze + Silver + Gold + Platinum rules.
- CI runs `hacs/action`, `home-assistant/actions/hassfest`, `ruff`, `mypy --strict`, and `pytest`.
- Brand assets (`icon.png`, `icon@2x.png`, `logo.png`) in `custom_components/wiener_linien_austria/brand/` unblock HACS validation until a PR to [home-assistant/brands](https://github.com/home-assistant/brands) merges.

**Documentation**
- README covers every Gold doc section (Data Updates, Use Cases, Automation Examples, Troubleshooting, Known Limitations, Supported Functions), U-Bahn line-colour reference table, Attribution, Contributors, and a bilingual (EN/DE) legal disclaimer.
- One-click "Add to HACS" and "Start setup" \`my.home-assistant.io\` buttons.

**Tests (46 total)**
- \`test_config_flow.py\` (9) — walks the full 3-step flow, search edge cases, duplicate-entry abort, cannot_connect on probe failure, catalogue-unavailable, reconfigure preserves \`unique_id\`, options updates interval.
- \`test_coordinator.py\` (18) — parser sort/filter/empty, all 6 error branches including rate-limit + repairs issue lifecycle, domain cooldown sleep + no-sleep, \`ConfigEntryNotReady\` on first-refresh failure, real session-chain fetch test.
- \`test_sensor.py\` (13) — state, unit, device_class, unique_id, DeviceInfo, attributes, grouped views, availability, end-to-end entity registration.
- \`test_diagnostics.py\` (1) — attribution + exact departure count derived from the fixture.
- \`test_static.py\` (5) — CSV parsing, search, \`Store\` roundtrip.

## Verification

All green locally and in CI:
- [x] \`pytest tests/ -v\` → 46/46 passing
- [x] \`mypy --strict --ignore-missing-imports custom_components/wiener_linien_austria\` → 7 files, 0 issues
- [x] \`ruff check .\` → clean
- [x] \`hassfest\` + HACS validation in CI → pass

## Breaking changes

None — this is the first tagged release.

## Attribution

Live data © Wiener Linien, published under CC BY 4.0. The attribution string \`Datenquelle: Wiener Linien (data.wien.gv.at), CC BY 4.0\` is emitted on every sensor, in diagnostics output, and rendered in the README.

## Commits in this PR

- \`32d3163\` feat: v0.1.0 — real-time Wiener Linien departure monitor
- \`fb7893d\` fix: add brand assets to satisfy HACS validation
- \`ad54083\` fix: add pythonpath=. so conftest.py top-level imports work in CI
- \`0d196d0\` docs: add HACS + config-flow + license + vibe-coded badges, contributors
- \`5473736\` test: tighten test suite to match Platinum claims (46 total, +23)
- \`d435fc9\` chore: gitignore .claude/ — per-project dev tooling stays local
- \`0da680d\` fix: translate 'Search again' option to German
- \`213fc0d\` docs: add bilingual legal disclaimer (mirrors tankstellen pattern)