### PR TITLE
feat: embedded Lovelace card with visual editor

### DIFF
--- a/custom_components/wiener_linien_austria/__init__.py
+++ b/custom_components/wiener_linien_austria/__init__.py
@@ -3,16 +3,21 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
+from pathlib import Path
 from typing import Any
 
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.components.http import StaticPathConfig
+from homeassistant.components.websocket_api import ActiveConnection  # type: ignore[attr-defined]
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
+from homeassistant.core import CoreState, Event, HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import DOMAIN, STATIC_CACHE_REFRESH_HOURS
+from .const import CARD_URL, CARD_VERSION, DOMAIN, STATIC_CACHE_REFRESH_HOURS
 from .coordinator import WienerLinienAustriaCoordinator
 from .static import async_refresh_catalogue
 
@@ -24,11 +29,25 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 STATIC_REFRESH_UNSUB_KEY = "static_refresh_unsub"
 
 
+@websocket_api.websocket_command(  # type: ignore[attr-defined]
+    {vol.Required("type"): "wiener_linien_austria/card_version"}
+)
+@websocket_api.async_response  # type: ignore[attr-defined]
+async def _websocket_card_version(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Return the current card version so the frontend can detect mismatches."""
+    connection.send_result(msg["id"], {"version": CARD_VERSION})
+
+
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
     """Set up the Wiener Linien Austria component.
 
     Schedules a weekly refresh of the stop catalogue. First fetch happens
     lazily on first config-flow use — no need to eagerly download at startup.
+    Also registers the Lovelace card once when the domain is loaded.
     """
     domain_data = hass.data.setdefault(DOMAIN, {})
 
@@ -43,7 +62,95 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
             cancel_on_shutdown=True,
         )
 
+    websocket_api.async_register_command(hass, _websocket_card_version)
+
+    async def _register_frontend(_event: Event | None = None) -> None:
+        await _async_register_card(hass)
+
+    if hass.state == CoreState.running:
+        await _register_frontend()
+    else:
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _register_frontend)
+
     return True
+
+
+async def _async_register_card(hass: HomeAssistant) -> None:
+    """Serve the card JS and add it to Lovelace resources."""
+    card_path = Path(__file__).parent / "www" / "wiener-linien-austria-card.js"
+    if not card_path.is_file():
+        _LOGGER.warning("Card JS not found at %s", card_path)
+        return
+
+    try:
+        await hass.http.async_register_static_paths(
+            [StaticPathConfig(CARD_URL, str(card_path), False)]
+        )
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("Static path already registered or unavailable")
+
+    try:
+        lovelace = hass.data.get("lovelace")
+        if lovelace is None:
+            _LOGGER.debug(
+                "Lovelace not yet available in hass.data — resource URL not updated. "
+                "The WebSocket version check will notify the user if the card JS is stale."
+            )
+            return
+
+        # HA <2024.x exposed .mode directly; newer versions use LovelaceData
+        # where mode lives on .config. Fall back gracefully when neither exists.
+        mode = getattr(lovelace, "mode", None) or getattr(
+            getattr(lovelace, "config", None), "mode", None
+        )
+        if mode is not None and mode != "storage":
+            _LOGGER.debug(
+                "Lovelace is in %s mode — resource URL must be managed manually", mode
+            )
+            return
+
+        resources = getattr(lovelace, "resources", None)
+        if resources is None:
+            _LOGGER.debug("Lovelace resources not accessible on this HA version")
+            return
+        await resources.async_load()
+
+        versioned_url = f"{CARD_URL}?v={CARD_VERSION}"
+
+        for item in resources.async_items():
+            existing_base = item.get("url", "").split("?")[0]
+            if existing_base == CARD_URL:
+                if item.get("url") == versioned_url:
+                    return  # already up to date
+                try:
+                    await resources.async_update_item(
+                        item["id"],
+                        {"res_type": "module", "url": versioned_url},
+                    )
+                except Exception as update_err:  # noqa: BLE001
+                    _LOGGER.debug(
+                        "async_update_item failed (%s), trying delete+recreate",
+                        update_err,
+                    )
+                    await resources.async_delete_item(item["id"])
+                    await resources.async_create_item(
+                        {"res_type": "module", "url": versioned_url}
+                    )
+                _LOGGER.info("Updated Lovelace resource to %s", versioned_url)
+                return
+
+        await resources.async_create_item(
+            {"res_type": "module", "url": versioned_url}
+        )
+        _LOGGER.info("Registered Lovelace resource %s", versioned_url)
+
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.warning(
+            "Could not register Lovelace resource (%s) – add manually: "
+            "Settings → Dashboards → Resources → %s (JavaScript module)",
+            err,
+            CARD_URL,
+        )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/wiener_linien_austria/const.py
+++ b/custom_components/wiener_linien_austria/const.py
@@ -50,3 +50,8 @@ LINE_TYPE_METRO: Final = "ptMetro"
 LINE_TYPE_TRAM: Final = "ptTram"
 LINE_TYPE_BUS_DAY: Final = "ptBusCity"
 LINE_TYPE_BUS_NIGHT: Final = "ptBusNight"
+
+# Lovelace card — version must match the `const CARD_VERSION` in
+# www/wiener-linien-austria-card.js byte-for-byte, else the reload banner loops.
+CARD_VERSION: Final = "0.1.0"
+CARD_URL: Final = "/wiener-linien-austria/wiener-linien-austria-card.js"

--- a/custom_components/wiener_linien_austria/manifest.json
+++ b/custom_components/wiener_linien_austria/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "wiener_linien_austria",
   "name": "Wiener Linien Austria",
-  "after_dependencies": ["http"],
+  "after_dependencies": ["frontend", "http", "lovelace"],
   "codeowners": ["@rolandzeiner"],
   "config_flow": true,
   "dependencies": [],

--- a/custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js
+++ b/custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js
@@ -1,0 +1,1015 @@
+/**
+ * Wiener Linien Austria Card v0.1.0
+ * Custom Lovelace card for Wiener Linien departure boards.
+ * https://github.com/rolandzeiner/wiener-linien-austria
+ */
+
+const CARD_VERSION = "0.1.0";
+
+// Metro line colours (authoritative per Wiener Linien CI). Non-metro lines
+// stay neutral until the user supplies overrides via `line_colors`.
+const METRO_COLORS = {
+  U1: "#E3000F",
+  U2: "#A862A4",
+  U3: "#EF7C00",
+  U4: "#00963F",
+  U5: "#008F95",
+  U6: "#9D6830",
+};
+
+const TRANSLATIONS = {
+  de: {
+    no_data: "Keine Abfahrten verfügbar",
+    betriebsschluss: "Betriebsschluss",
+    min: "min",
+    now: "jetzt",
+    version_update:
+      "Wiener Linien Austria wurde auf v{v} aktualisiert — bitte neu laden",
+    version_reload: "Neu laden",
+    no_entities_picked: "Keine Haltestelle ausgewählt",
+    no_entities_available: "Keine Wiener-Linien-Sensoren gefunden",
+    barrier_free_title: "Barrierefrei zugänglich",
+    disturbance_title: "Verkehrsbehinderung gemeldet",
+    dir_h: "H",
+    dir_r: "R",
+    dir_both: "Beide",
+    editor: {
+      section_sensors: "Haltestellen",
+      sensors_hint: "Eine oder mehrere Haltestellen auswählen",
+      section_filters: "Filter pro Haltestelle",
+      filters_hint: "Linien und/oder Richtung pro Haltestelle einschränken",
+      lines_label: "Linien",
+      direction_label: "Richtung",
+      section_colors: "Linienfarben",
+      colors_hint:
+        "Optional: Farben überschreiben. U-Bahn-Standardwerte sind gesetzt.",
+      reset_color: "Zurücksetzen",
+      section_display: "Anzeige",
+      max_departures: "Anzahl Abfahrten pro Haltestelle",
+      show_accessibility: "Barrierefrei-Symbol anzeigen",
+      no_sensors_available:
+        "Keine Wiener-Linien-Sensoren verfügbar. Erst eine Haltestelle über Einstellungen → Geräte & Dienste hinzufügen.",
+      no_lines_available:
+        "Linien erscheinen hier, sobald Haltestellen ausgewählt wurden.",
+    },
+  },
+  en: {
+    no_data: "No departures available",
+    betriebsschluss: "End of service",
+    min: "min",
+    now: "now",
+    version_update:
+      "Wiener Linien Austria updated to v{v} — please reload",
+    version_reload: "Reload",
+    no_entities_picked: "No stop selected",
+    no_entities_available: "No Wiener Linien sensors found",
+    barrier_free_title: "Step-free access",
+    disturbance_title: "Traffic disruption reported",
+    dir_h: "H",
+    dir_r: "R",
+    dir_both: "Both",
+    editor: {
+      section_sensors: "Stops",
+      sensors_hint: "Pick one or more stops to display",
+      section_filters: "Per-stop filters",
+      filters_hint: "Optionally restrict lines or direction per stop",
+      lines_label: "Lines",
+      direction_label: "Direction",
+      section_colors: "Line colours",
+      colors_hint:
+        "Optional overrides. Metro defaults are already set.",
+      reset_color: "Reset",
+      section_display: "Display",
+      max_departures: "Departures per stop",
+      show_accessibility: "Show step-free icon",
+      no_sensors_available:
+        "No Wiener Linien sensors available. Add a stop first via Settings → Devices & Services.",
+      no_lines_available:
+        "Lines appear here once stops are selected.",
+    },
+  },
+};
+
+const _esc = (s) =>
+  String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+function _findWienerLinienEntities(hass) {
+  if (!hass || !hass.states) return [];
+  return Object.keys(hass.states).filter((eid) => {
+    if (!eid.startsWith("sensor.")) return false;
+    const a = hass.states[eid].attributes;
+    return (
+      a &&
+      typeof a.diva === "number" &&
+      Array.isArray(a.departures) &&
+      typeof a.attribution === "string" &&
+      a.attribution.startsWith("Datenquelle: Wiener Linien")
+    );
+  });
+}
+
+function _normaliseStopEntry(raw) {
+  if (typeof raw === "string") {
+    return raw.includes(".") ? { entity: raw } : null;
+  }
+  if (!raw || typeof raw !== "object" || typeof raw.entity !== "string") {
+    return null;
+  }
+  const out = { entity: raw.entity };
+  if (Array.isArray(raw.lines)) {
+    const lines = raw.lines.filter(
+      (l) => typeof l === "string" && l.length > 0,
+    );
+    if (lines.length) out.lines = lines;
+  }
+  if (raw.direction === "H" || raw.direction === "R") {
+    out.direction = raw.direction;
+  }
+  return out;
+}
+
+function _normaliseConfig(config) {
+  // Back-compat: accept a single `entity` string at top level (v0.1.0 shape).
+  const out = { ...(config || {}) };
+  if (typeof out.entity === "string" && out.entity.includes(".")) {
+    if (!Array.isArray(out.entities) || out.entities.length === 0) {
+      out.entities = [out.entity];
+    }
+  }
+  delete out.entity;
+
+  const rawList = Array.isArray(out.entities) ? out.entities : [];
+  out.entities = rawList
+    .map(_normaliseStopEntry)
+    .filter((e) => e !== null);
+
+  const n = parseInt(out.max_departures, 10);
+  out.max_departures = Number.isFinite(n) ? Math.max(1, Math.min(20, n)) : 6;
+
+  if (out.line_colors && typeof out.line_colors === "object") {
+    const clean = {};
+    for (const [k, v] of Object.entries(out.line_colors)) {
+      if (typeof k === "string" && typeof v === "string" && /^#[0-9a-f]{3,8}$/i.test(v)) {
+        clean[k.toUpperCase()] = v;
+      }
+    }
+    out.line_colors = clean;
+  } else {
+    out.line_colors = {};
+  }
+
+  out.show_accessibility = out.show_accessibility === true;
+
+  return out;
+}
+
+function _colorForLine(line, overrides) {
+  const key = String(line || "").toUpperCase();
+  if (overrides && overrides[key]) return overrides[key];
+  if (METRO_COLORS[key]) return METRO_COLORS[key];
+  return "var(--primary-color)";
+}
+
+function _filterDepartures(departures, stopCfg) {
+  if (!Array.isArray(departures)) return [];
+  const wantLines = stopCfg.lines && stopCfg.lines.length ? new Set(stopCfg.lines) : null;
+  const wantDir = stopCfg.direction || null;
+  return departures.filter((d) => {
+    if (wantLines && !wantLines.has(d.line)) return false;
+    if (wantDir && d.direction !== wantDir) return false;
+    return true;
+  });
+}
+
+function _collectLinesInSelection(hass, entities) {
+  const seen = new Set();
+  for (const stop of entities) {
+    const a = hass?.states[stop.entity]?.attributes;
+    const grouped = a?.departures_by_line;
+    if (grouped && typeof grouped === "object") {
+      for (const line of Object.keys(grouped)) seen.add(line);
+    }
+  }
+  return [...seen].sort();
+}
+
+const CARD_STYLE = `
+  .wl-card { padding: 12px 16px; }
+  .wl-banner {
+    background: var(--warning-color, #ffa000);
+    color: #fff;
+    padding: 8px 12px;
+    margin: -12px -16px 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .wl-banner button {
+    background: #fff;
+    color: var(--warning-color, #ffa000);
+    border: none;
+    border-radius: 4px;
+    padding: 4px 10px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .wl-stop { margin-bottom: 14px; }
+  .wl-stop:last-of-type { margin-bottom: 0; }
+  .wl-header {
+    font-size: 1.05em;
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+  .wl-empty {
+    padding: 18px 0;
+    color: var(--secondary-text-color);
+    text-align: center;
+  }
+  .wl-row {
+    display: grid;
+    grid-template-columns: 44px 1fr auto auto;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 0;
+    border-bottom: 1px solid var(--divider-color, rgba(0,0,0,0.08));
+  }
+  .wl-row:last-child { border-bottom: none; }
+  .wl-line {
+    text-align: center;
+    font-weight: 700;
+    color: #fff;
+    border-radius: 4px;
+    padding: 2px 4px;
+    font-size: 0.9em;
+    background: var(--primary-color);
+  }
+  .wl-towards {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .wl-flags {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--secondary-text-color);
+  }
+  .wl-flags ha-icon { --mdc-icon-size: 16px; }
+  .wl-flags .disturbance { color: var(--warning-color, #ffa000); }
+  .wl-countdown {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    min-width: 50px;
+    text-align: right;
+  }
+  .wl-attr {
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid var(--divider-color, rgba(0,0,0,0.08));
+    font-size: 0.75em;
+    color: var(--secondary-text-color);
+    text-align: center;
+  }
+`;
+
+class WienerLinienAustriaCard extends HTMLElement {
+  _config = {};
+  _hass = null;
+  _versionMismatch = null;
+  _lastFingerprint = null;
+
+  setConfig(config) {
+    this._config = _normaliseConfig(config);
+    this._lastFingerprint = null;
+    this._render();
+  }
+
+  set hass(hass) {
+    const first = !this._hass;
+    this._hass = hass;
+    if (first) {
+      this._checkCardVersion();
+    }
+    const fp = this._fingerprint();
+    if (fp === this._lastFingerprint) return;
+    this._lastFingerprint = fp;
+    this._render();
+  }
+
+  getCardSize() {
+    const n = (this._config.entities || []).length || 1;
+    return Math.min(12, 3 + n * 3);
+  }
+
+  static getConfigElement() {
+    return document.createElement("wiener-linien-austria-card-editor");
+  }
+
+  static getStubConfig(hass) {
+    const entities = _findWienerLinienEntities(hass);
+    return {
+      entities: entities.length ? [entities[0]] : [],
+      max_departures: 6,
+    };
+  }
+
+  async _checkCardVersion() {
+    if (!this._hass?.callWS) return;
+    try {
+      const result = await this._hass.callWS({
+        type: "wiener_linien_austria/card_version",
+      });
+      if (result?.version && result.version !== CARD_VERSION) {
+        this._versionMismatch = result.version;
+        this._lastFingerprint = null;
+        this._render();
+      }
+    } catch (_) {
+      /* backend may not support the command yet */
+    }
+  }
+
+  _lang() {
+    const hl = this._hass?.language || "en";
+    return hl.startsWith("de") ? "de" : "en";
+  }
+
+  _t(key) {
+    return TRANSLATIONS[this._lang()][key] ?? TRANSLATIONS.en[key] ?? key;
+  }
+
+  _resolveEntities() {
+    const picked = Array.isArray(this._config.entities)
+      ? this._config.entities.filter((s) => this._hass?.states[s.entity])
+      : [];
+    if (picked.length) return picked;
+    const available = _findWienerLinienEntities(this._hass);
+    return available.length ? [{ entity: available[0] }] : [];
+  }
+
+  _fingerprint() {
+    if (!this._hass) return null;
+    const cfgKey = JSON.stringify(this._config);
+    const stops = this._resolveEntities();
+    const stopKeys = stops.map((s) => {
+      const a = this._hass.states[s.entity]?.attributes || {};
+      const filtered = _filterDepartures(a.departures || [], s);
+      const max = this._config.max_departures;
+      const depKey = filtered
+        .slice(0, max)
+        .map(
+          (d) =>
+            `${d.line}|${d.towards}|${d.countdown}|${d.direction}|${
+              d.traffic_jam ? 1 : 0
+            }|${d.barrier_free ? 1 : 0}`,
+        )
+        .join(";");
+      return `${s.entity}@${a.server_time || ""}#${depKey}`;
+    });
+    return `${this._versionMismatch || ""}||${cfgKey}||${stopKeys.join("|||")}`;
+  }
+
+  _render() {
+    if (!this._hass) return;
+
+    const stops = this._resolveEntities();
+    const max = this._config.max_departures;
+    const overrides = this._config.line_colors || {};
+    const showA11y = this._config.show_accessibility;
+
+    const attribution =
+      stops
+        .map((s) => this._hass.states[s.entity]?.attributes?.attribution)
+        .find((v) => typeof v === "string" && v.length > 0) ||
+      "Datenquelle: Wiener Linien (data.wien.gv.at), CC BY 4.0";
+
+    const body = stops.length
+      ? stops.map((s) => this._renderStop(s, max, overrides, showA11y)).join("")
+      : this._renderEmpty();
+
+    this.innerHTML = `
+      <ha-card>
+        <style>${CARD_STYLE}</style>
+        <div class="wl-card">
+          ${this._versionMismatch ? this._renderBanner() : ""}
+          ${body}
+          <div class="wl-attr">${_esc(attribution)}</div>
+        </div>
+      </ha-card>
+    `;
+
+    const reloadBtn = this.querySelector(".wl-banner button");
+    if (reloadBtn) {
+      reloadBtn.addEventListener("click", () => this._reload());
+    }
+  }
+
+  _renderEmpty() {
+    const available = _findWienerLinienEntities(this._hass);
+    const key = available.length ? "no_entities_picked" : "no_entities_available";
+    return `<div class="wl-empty">${_esc(this._t(key))}</div>`;
+  }
+
+  _renderStop(stopCfg, max, overrides, showA11y) {
+    const state = this._hass.states[stopCfg.entity];
+    const attrs = state?.attributes ?? {};
+    const title = attrs.stop_name || attrs.friendly_name || stopCfg.entity;
+    const allDepartures = Array.isArray(attrs.departures) ? attrs.departures : [];
+    const filtered = _filterDepartures(allDepartures, stopCfg);
+    const rows = filtered.slice(0, max);
+
+    let rowsHtml;
+    if (rows.length) {
+      rowsHtml = rows
+        .map((d) => this._renderRow(d, overrides, showA11y))
+        .join("");
+    } else {
+      // "Betriebsschluss" when upstream confirmed no trips (server_time set);
+      // "No departures available" when we simply have no data yet.
+      const key = attrs.server_time ? "betriebsschluss" : "no_data";
+      rowsHtml = `<div class="wl-empty">${_esc(this._t(key))}</div>`;
+    }
+
+    return `
+      <div class="wl-stop">
+        <div class="wl-header">${_esc(title)}</div>
+        ${rowsHtml}
+      </div>
+    `;
+  }
+
+  _renderRow(d, overrides, showA11y) {
+    const line = String(d.line || "?");
+    const color = _colorForLine(line, overrides);
+    const towards = _esc(d.towards || "");
+    const cd = Number.isFinite(d.countdown) ? d.countdown : null;
+    const cdLabel =
+      cd === null ? "—" : cd <= 0 ? this._t("now") : `${cd} ${this._t("min")}`;
+
+    const flags = [];
+    if (d.traffic_jam) {
+      flags.push(
+        `<ha-icon class="disturbance" icon="mdi:alert-circle" title="${_esc(
+          this._t("disturbance_title"),
+        )}"></ha-icon>`,
+      );
+    }
+    if (showA11y && d.barrier_free) {
+      flags.push(
+        `<ha-icon class="a11y" icon="mdi:wheelchair-accessibility" title="${_esc(
+          this._t("barrier_free_title"),
+        )}"></ha-icon>`,
+      );
+    }
+    const flagsHtml = flags.length
+      ? `<span class="wl-flags">${flags.join("")}</span>`
+      : `<span></span>`;
+
+    return `
+      <div class="wl-row">
+        <div class="wl-line" style="background:${color}">${_esc(line)}</div>
+        <div class="wl-towards">${towards}</div>
+        ${flagsHtml}
+        <div class="wl-countdown">${_esc(cdLabel)}</div>
+      </div>
+    `;
+  }
+
+  _renderBanner() {
+    const msg = this._t("version_update").replace("{v}", this._versionMismatch);
+    return `
+      <div class="wl-banner">
+        <span>${_esc(msg)}</span>
+        <button type="button">${_esc(this._t("version_reload"))}</button>
+      </div>
+    `;
+  }
+
+  async _reload() {
+    try {
+      if (window.caches?.keys) {
+        const keys = await window.caches.keys();
+        await Promise.all(keys.map((k) => window.caches.delete(k)));
+      }
+    } catch (_) {
+      /* best-effort cache wipe */
+    }
+    window.location.reload();
+  }
+}
+
+// ============================================================
+// Visual Card Editor
+// ============================================================
+
+const EDITOR_STYLE = `
+  .editor {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .editor-section {
+    background: var(--secondary-background-color, rgba(0,0,0,0.04));
+    border-radius: 12px;
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .section-header {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+    color: var(--secondary-text-color);
+  }
+  .editor-hint {
+    font-size: 12px;
+    color: var(--secondary-text-color);
+    line-height: 1.4;
+  }
+  .entity-chips, .line-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 12px;
+    border-radius: 16px;
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.15s;
+    border: 1px solid var(--divider-color);
+    background: var(--card-background-color, #fff);
+    color: var(--primary-text-color);
+  }
+  .chip.selected {
+    background: var(--primary-color);
+    color: var(--text-primary-color, #fff);
+    border-color: var(--primary-color);
+  }
+  .chip:hover { opacity: 0.85; }
+  .chip .stop-name { font-weight: 500; }
+  .chip .eid {
+    font-size: 11px;
+    opacity: 0.7;
+  }
+  .stop-filter {
+    padding: 8px 10px;
+    border: 1px solid var(--divider-color);
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .stop-filter-header {
+    font-size: 13px;
+    font-weight: 500;
+  }
+  .stop-filter-row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .stop-filter-row-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--secondary-text-color);
+  }
+  .direction-buttons {
+    display: inline-flex;
+    gap: 4px;
+  }
+  .direction-buttons button {
+    padding: 4px 12px;
+    border-radius: 14px;
+    border: 1px solid var(--divider-color);
+    background: var(--card-background-color, #fff);
+    color: var(--primary-text-color);
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .direction-buttons button.active {
+    background: var(--primary-color);
+    color: var(--text-primary-color, #fff);
+    border-color: var(--primary-color);
+  }
+  .color-row {
+    display: grid;
+    grid-template-columns: 44px 1fr auto auto;
+    align-items: center;
+    gap: 10px;
+  }
+  .color-row .line-preview {
+    text-align: center;
+    font-weight: 700;
+    color: #fff;
+    border-radius: 4px;
+    padding: 2px 4px;
+    font-size: 0.9em;
+  }
+  .color-row input[type="color"] {
+    width: 40px;
+    height: 28px;
+    padding: 0;
+    border: 1px solid var(--divider-color);
+    border-radius: 4px;
+    background: transparent;
+    cursor: pointer;
+  }
+  .color-row .reset-btn {
+    font-size: 11px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--divider-color);
+    background: transparent;
+    color: var(--secondary-text-color);
+    cursor: pointer;
+  }
+  .color-row .reset-btn[disabled] {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+  .slider-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .slider-row input[type="range"] {
+    flex: 1;
+    accent-color: var(--primary-color);
+  }
+  .slider-row .slider-label {
+    font-size: 13px;
+    color: var(--primary-text-color);
+    min-width: 180px;
+  }
+  .slider-value {
+    min-width: 24px;
+    text-align: center;
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--primary-color);
+  }
+  .toggle-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .toggle-row label {
+    font-size: 13px;
+    color: var(--primary-text-color);
+    cursor: pointer;
+  }
+`;
+
+class WienerLinienAustriaCardEditor extends HTMLElement {
+  _config = {};
+  _hass = null;
+
+  setConfig(config) {
+    this._config = _normaliseConfig(config);
+    this._render();
+  }
+
+  set hass(hass) {
+    const first = !this._hass;
+    this._hass = hass;
+    if (first) this._render();
+  }
+
+  _lang() {
+    const hl = this._hass?.language || "en";
+    return hl.startsWith("de") ? "de" : "en";
+  }
+
+  _et(key) {
+    return (
+      TRANSLATIONS[this._lang()]?.editor?.[key]
+      ?? TRANSLATIONS.en.editor[key]
+      ?? key
+    );
+  }
+
+  _t(key) {
+    return TRANSLATIONS[this._lang()][key] ?? TRANSLATIONS.en[key] ?? key;
+  }
+
+  _fireChanged() {
+    this.dispatchEvent(
+      new CustomEvent("config-changed", {
+        detail: { config: { ...this._config } },
+      }),
+    );
+  }
+
+  _updateStop(eid, mutator) {
+    const entities = (this._config.entities || []).map((s) =>
+      s.entity === eid ? mutator({ ...s }) : s,
+    );
+    this._config = { ...this._config, entities };
+    this._fireChanged();
+    this._render();
+  }
+
+  _toggleStop(eid) {
+    const entities = [...(this._config.entities || [])];
+    const idx = entities.findIndex((s) => s.entity === eid);
+    const next = idx >= 0
+      ? entities.filter((_, i) => i !== idx)
+      : [...entities, { entity: eid }];
+    this._config = { ...this._config, entities: next };
+    this._fireChanged();
+    this._render();
+  }
+
+  _toggleLine(eid, line) {
+    this._updateStop(eid, (s) => {
+      const cur = new Set(s.lines || []);
+      if (cur.has(line)) cur.delete(line);
+      else cur.add(line);
+      if (cur.size > 0) s.lines = [...cur];
+      else delete s.lines;
+      return s;
+    });
+  }
+
+  _setDirection(eid, dir) {
+    this._updateStop(eid, (s) => {
+      if (dir === null) delete s.direction;
+      else s.direction = dir;
+      return s;
+    });
+  }
+
+  _setLineColor(line, color) {
+    const colors = { ...(this._config.line_colors || {}) };
+    colors[line.toUpperCase()] = color;
+    this._config = { ...this._config, line_colors: colors };
+    this._fireChanged();
+    this._render();
+  }
+
+  _resetLineColor(line) {
+    const colors = { ...(this._config.line_colors || {}) };
+    delete colors[line.toUpperCase()];
+    this._config = { ...this._config, line_colors: colors };
+    this._fireChanged();
+    this._render();
+  }
+
+  _render() {
+    if (!this._hass) return;
+
+    const available = _findWienerLinienEntities(this._hass);
+    const selected = this._config.entities || [];
+    const selectedIds = new Set(selected.map((s) => s.entity));
+    const max = this._config.max_departures ?? 6;
+    const overrides = this._config.line_colors || {};
+    const showA11y = this._config.show_accessibility === true;
+
+    // ----- Stop chips -----
+    const stopChips = available.length
+      ? available
+          .map((eid) => {
+            const a = this._hass.states[eid]?.attributes;
+            const stopName = a?.stop_name || a?.friendly_name || eid;
+            const isSelected = selectedIds.has(eid);
+            return `
+              <button
+                type="button"
+                class="chip ${isSelected ? "selected" : ""}"
+                data-action="toggle-stop"
+                data-entity="${_esc(eid)}"
+              >
+                <span class="stop-name">${_esc(stopName)}</span>
+                <span class="eid">${_esc(eid.split(".")[1] || eid)}</span>
+              </button>
+            `;
+          })
+          .join("")
+      : `<div class="editor-hint">${_esc(this._et("no_sensors_available"))}</div>`;
+
+    // ----- Per-stop filter blocks -----
+    const filterBlocks = selected.length
+      ? selected
+          .map((stop) => {
+            const a = this._hass.states[stop.entity]?.attributes;
+            if (!a) return "";
+            const stopName = a.stop_name || stop.entity;
+            const linesAtStop = a.departures_by_line
+              ? Object.keys(a.departures_by_line).sort()
+              : [];
+            const picked = new Set(stop.lines || []);
+            const dir = stop.direction || null;
+
+            const lineChips = linesAtStop.length
+              ? linesAtStop
+                  .map((line) => {
+                    const isOn = picked.size === 0 || picked.has(line);
+                    const color = _colorForLine(line, overrides);
+                    return `
+                      <button
+                        type="button"
+                        class="chip ${isOn ? "selected" : ""}"
+                        data-action="toggle-line"
+                        data-entity="${_esc(stop.entity)}"
+                        data-line="${_esc(line)}"
+                        style="${isOn ? `background:${color};border-color:${color};color:#fff` : ""}"
+                      >${_esc(line)}</button>
+                    `;
+                  })
+                  .join("")
+              : `<div class="editor-hint">${_esc(this._et("no_lines_available"))}</div>`;
+
+            return `
+              <div class="stop-filter">
+                <div class="stop-filter-header">${_esc(stopName)}</div>
+                <div class="stop-filter-row">
+                  <div class="stop-filter-row-label">${_esc(this._et("lines_label"))}</div>
+                  <div class="line-chips">${lineChips}</div>
+                </div>
+                <div class="stop-filter-row">
+                  <div class="stop-filter-row-label">${_esc(this._et("direction_label"))}</div>
+                  <div class="direction-buttons" data-entity="${_esc(stop.entity)}">
+                    <button type="button" data-dir="H" class="${dir === "H" ? "active" : ""}">${_esc(this._t("dir_h"))}</button>
+                    <button type="button" data-dir="R" class="${dir === "R" ? "active" : ""}">${_esc(this._t("dir_r"))}</button>
+                    <button type="button" data-dir="" class="${dir === null ? "active" : ""}">${_esc(this._t("dir_both"))}</button>
+                  </div>
+                </div>
+              </div>
+            `;
+          })
+          .join("")
+      : `<div class="editor-hint">${_esc(this._et("sensors_hint"))}</div>`;
+
+    // ----- Line colour overrides -----
+    const linesInPlay = _collectLinesInSelection(this._hass, selected);
+    const colorRows = linesInPlay.length
+      ? linesInPlay
+          .map((line) => {
+            const current = _colorForLine(line, overrides);
+            const hasOverride = Boolean(overrides[line.toUpperCase()]);
+            return `
+              <div class="color-row">
+                <div class="line-preview" style="background:${current}">${_esc(line)}</div>
+                <span>${_esc(line)}</span>
+                <input type="color" data-line="${_esc(line)}" value="${_esc(current.startsWith("#") ? current : "#888888")}" />
+                <button type="button" class="reset-btn" data-reset-line="${_esc(line)}" ${hasOverride ? "" : "disabled"}>${_esc(this._et("reset_color"))}</button>
+              </div>
+            `;
+          })
+          .join("")
+      : `<div class="editor-hint">${_esc(this._et("no_lines_available"))}</div>`;
+
+    this.innerHTML = `
+      <div class="editor">
+        <style>${EDITOR_STYLE}</style>
+
+        <div class="editor-section">
+          <div class="section-header">${_esc(this._et("section_sensors"))}</div>
+          <div class="editor-hint">${_esc(this._et("sensors_hint"))}</div>
+          <div class="entity-chips">${stopChips}</div>
+        </div>
+
+        <div class="editor-section">
+          <div class="section-header">${_esc(this._et("section_filters"))}</div>
+          <div class="editor-hint">${_esc(this._et("filters_hint"))}</div>
+          ${filterBlocks}
+        </div>
+
+        <div class="editor-section">
+          <div class="section-header">${_esc(this._et("section_colors"))}</div>
+          <div class="editor-hint">${_esc(this._et("colors_hint"))}</div>
+          ${colorRows}
+        </div>
+
+        <div class="editor-section">
+          <div class="section-header">${_esc(this._et("section_display"))}</div>
+          <div class="slider-row">
+            <span class="slider-label">${_esc(this._et("max_departures"))}</span>
+            <input
+              type="range"
+              min="1"
+              max="20"
+              step="1"
+              value="${max}"
+              data-field="max_departures"
+            />
+            <span class="slider-value">${max}</span>
+          </div>
+          <div class="toggle-row">
+            <label for="wl-a11y-toggle">${_esc(this._et("show_accessibility"))}</label>
+            <input
+              id="wl-a11y-toggle"
+              type="checkbox"
+              data-field="show_accessibility"
+              ${showA11y ? "checked" : ""}
+            />
+          </div>
+        </div>
+      </div>
+    `;
+
+    this._attachListeners();
+  }
+
+  _attachListeners() {
+    // Stop toggle
+    this.querySelectorAll('[data-action="toggle-stop"]').forEach((chip) => {
+      chip.addEventListener("click", () => this._toggleStop(chip.dataset.entity));
+    });
+
+    // Line filter toggle
+    this.querySelectorAll('[data-action="toggle-line"]').forEach((chip) => {
+      chip.addEventListener("click", () =>
+        this._toggleLine(chip.dataset.entity, chip.dataset.line),
+      );
+    });
+
+    // Direction buttons
+    this.querySelectorAll(".direction-buttons").forEach((grp) => {
+      const eid = grp.dataset.entity;
+      grp.querySelectorAll("button").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const dir = btn.dataset.dir;
+          this._setDirection(eid, dir === "" ? null : dir);
+        });
+      });
+    });
+
+    // Colour pickers
+    this.querySelectorAll('input[type="color"][data-line]').forEach((input) => {
+      input.addEventListener("change", (e) => {
+        this._setLineColor(input.dataset.line, e.target.value);
+      });
+    });
+    this.querySelectorAll("[data-reset-line]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        if (btn.disabled) return;
+        this._resetLineColor(btn.dataset.resetLine);
+      });
+    });
+
+    // Max-departures slider
+    this.querySelectorAll('input[type="range"]').forEach((input) => {
+      ["keydown", "keyup", "keypress"].forEach((evt) => {
+        input.addEventListener(evt, (e) => e.stopPropagation());
+      });
+      input.addEventListener("input", (e) => {
+        const label = e.target.nextElementSibling;
+        if (label) label.textContent = e.target.value;
+      });
+      input.addEventListener("change", (e) => {
+        const field = e.target.dataset.field;
+        const v = parseInt(e.target.value, 10);
+        if (!Number.isFinite(v)) return;
+        this._config = { ...this._config, [field]: v };
+        this._fireChanged();
+      });
+    });
+
+    // Accessibility toggle
+    this.querySelectorAll('input[type="checkbox"][data-field]').forEach((cb) => {
+      cb.addEventListener("change", (e) => {
+        const field = e.target.dataset.field;
+        this._config = { ...this._config, [field]: e.target.checked };
+        this._fireChanged();
+        this._render();
+      });
+    });
+  }
+}
+
+try {
+  if (!customElements.get("wiener-linien-austria-card")) {
+    customElements.define("wiener-linien-austria-card", WienerLinienAustriaCard);
+  }
+  if (!customElements.get("wiener-linien-austria-card-editor")) {
+    customElements.define(
+      "wiener-linien-austria-card-editor",
+      WienerLinienAustriaCardEditor,
+    );
+  }
+} catch (e) {
+  console.error("[Wiener Linien Austria] custom element registration failed", e);
+}
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: "wiener-linien-austria-card",
+  name: "Wiener Linien Austria",
+  description: "Abfahrtsmonitor für Wiener Linien Stationen.",
+  preview: false,
+  documentationURL: "https://github.com/rolandzeiner/wiener-linien-austria",
+});


### PR DESCRIPTION
## Summary
- Introduces the Wiener Linien Austria Lovelace card + visual editor. Registration mirrors the tankstellen pattern (WebSocket `card_version`, post-startup `async_register_static_paths`, Lovelace resource upsert with `?v=` cache-bust). `manifest.json` grows `after_dependencies: [frontend, http, lovelace]`.
- Card auto-discovers sensors by attribute fingerprint (`diva` + `departures` + CC-BY attribution prefix) — no entity_id prefix required, zero impact on existing installs.
- Visual editor ships with chip-based stop picker, per-stop line + direction filters, per-line colour overrides (U1–U6 metro CI defaults built in; tram/bus/any override via `line_colors:`), max-departures slider (1–20), and opt-in step-free icon toggle.
- Row-level indicators for `traffic_jam` (`mdi:alert-circle`, warning colour) and `barrier_free` (`mdi:wheelchair-accessibility`, opt-in).
- "Betriebsschluss" / "End of service" empty state when upstream confirms no trips via `server_time`.
- Fingerprint-based render short-circuit prevents DOM thrash on every coordinator tick — pre-empts the flicker bug that hit the closest existing Vienna card.
- `CARD_VERSION = "0.1.0"` locked byte-for-byte in `const.py` and card JS; bump on release only so the reload banner doesn't loop.

## Test plan
- [x] `python3 -m pytest tests/ -v` — 46/46 pass
- [x] `mypy --strict --ignore-missing-imports custom_components/wiener_linien_austria` — clean
- [x] `ruff check .` — clean
- [x] Dev-pushed to live HA (rpi25); MCP `get_state` confirms the card's fingerprint inputs (`server_time`, `departures[].countdown`, `traffic_jam`, `barrier_free`) are populated on `sensor.westbahnhof_abfahrten`
- [x] Card renders with correct U6 metro colour, direction-sorted departures, CC-BY attribution footer
- [x] Editor chips toggle stops; line filter and direction buttons apply pre-slice
- [x] Colour picker overrides persist through `_fireChanged` and roundtrip through `_normaliseConfig`
- [x] Manual: enable `show_accessibility` → wheelchair icon on every Westbahnhof row (all `barrier_free: true`)
- [x] Manual: wait 10+ coordinator ticks, confirm no flicker in DevTools Performance
- [ ] Manual: verify Betriebsschluss label overnight (empty `departures` + `server_time` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)