### PR TITLE
fix: send identifying User-Agent on all outbound requests

### DIFF
--- a/custom_components/wiener_linien_austria/config_flow.py
+++ b/custom_components/wiener_linien_austria/config_flow.py
@@ -50,6 +50,7 @@ from .const import (
     MAX_POLL_SECONDS,
     MIN_POLL_SECONDS,
     MONITOR_ENDPOINT,
+    USER_AGENT,
 )
 from .static import Station, async_load_catalogue
 
@@ -85,7 +86,10 @@ async def _probe_monitor_lines(
     params = [("stopId", str(r)) for r in rbls]
     try:
         resp = await session.get(
-            url, params=params, timeout=aiohttp.ClientTimeout(total=10)
+            url,
+            params=params,
+            headers={"User-Agent": USER_AGENT},
+            timeout=aiohttp.ClientTimeout(total=10),
         )
         resp.raise_for_status()
         body = await resp.json()

--- a/custom_components/wiener_linien_austria/const.py
+++ b/custom_components/wiener_linien_austria/const.py
@@ -3,7 +3,18 @@ from __future__ import annotations
 
 from typing import Final
 
+from homeassistant.const import __version__ as _HA_VERSION
+
 DOMAIN: Final = "wiener_linien_austria"
+
+# Integration version — must match manifest.json "version" field.
+INTEGRATION_VERSION: Final = "0.1.0"
+
+# User-Agent header sent on every outbound request. Identifying ourselves
+# beyond HA's default clientsession UA lets Wiener Linien traffic-shape or
+# reach out to *this* integration specifically rather than blanket-blocking
+# the HA UA for everyone. HA convention: "HomeAssistant/{ver} {slug}/{ver}".
+USER_AGENT: Final = f"HomeAssistant/{_HA_VERSION} {DOMAIN}/{INTEGRATION_VERSION}"
 
 # Config entry keys
 CONF_DIVA: Final = "diva"

--- a/custom_components/wiener_linien_austria/coordinator.py
+++ b/custom_components/wiener_linien_austria/coordinator.py
@@ -27,6 +27,7 @@ from .const import (
     DOMAIN_LAST_CALL_KEY,
     ERR_RATE_LIMIT,
     MONITOR_ENDPOINT,
+    USER_AGENT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -163,10 +164,13 @@ class WienerLinienAustriaCoordinator(DataUpdateCoordinator[MonitorData]):
         params: list[tuple[str, str]] = [
             ("stopId", str(rbl)) for rbl in self._rbls
         ]
+        headers = {"User-Agent": USER_AGENT}
         timeout = aiohttp.ClientTimeout(total=30)
 
         try:
-            resp = await self._session.get(url, params=params, timeout=timeout)
+            resp = await self._session.get(
+                url, params=params, headers=headers, timeout=timeout
+            )
             resp.raise_for_status()
         except asyncio.TimeoutError as err:
             raise UpdateFailed(

--- a/custom_components/wiener_linien_austria/static.py
+++ b/custom_components/wiener_linien_austria/static.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, STATIC_FILES
+from .const import DOMAIN, STATIC_FILES, USER_AGENT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -139,7 +139,9 @@ async def _download_text(
     session: aiohttp.ClientSession, url: str, timeout: aiohttp.ClientTimeout
 ) -> str:
     """GET a CSV URL and return its UTF-8 text body."""
-    resp = await session.get(url, timeout=timeout)
+    resp = await session.get(
+        url, headers={"User-Agent": USER_AGENT}, timeout=timeout
+    )
     resp.raise_for_status()
     return await resp.text()
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -127,6 +127,30 @@ async def test_fetch_success_real_chain(
     assert coordinator.server_time == monitor_fixture["message"]["serverTime"]
 
 
+async def test_fetch_sends_user_agent_header(
+    hass: HomeAssistant, monitor_fixture
+) -> None:
+    """Every outbound /monitor request carries the integration UA header.
+
+    Identifying as wiener_linien_austria/{version} lets Wiener Linien
+    traffic-shape this integration specifically rather than blanket-blocking
+    the default Home Assistant UA.
+    """
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+    coordinator = WienerLinienAustriaCoordinator(hass, entry)
+
+    mock_resp = _ok_response(monitor_fixture)
+    mock_get = AsyncMock(return_value=mock_resp)
+    with patch.object(coordinator._session, "get", new=mock_get):
+        await coordinator._async_update_data()
+
+    _args, kwargs = mock_get.call_args
+    ua = kwargs["headers"]["User-Agent"]
+    assert ua.startswith("HomeAssistant/")
+    assert " wiener_linien_austria/" in ua
+
+
 async def test_http_error_raises_update_failed(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Summary
- Adds `INTEGRATION_VERSION` + `USER_AGENT` constants in `const.py`, building `HomeAssistant/{ver} wiener_linien_austria/{ver}` per HA convention (same shape as the tankstellen-austria integration uses).
- Wires the header into every outbound call touching `wienerlinien.at`:
  - `coordinator.py::_async_update_data` — the `/monitor` polling fetch
  - `config_flow.py::_probe_monitor_lines` — the setup-time line probe
  - `static.py::_download_text` — the weekly `haltestellen.csv` + `haltepunkte.csv` downloads
- Lets Wiener Linien traffic-shape or reach out to this integration specifically rather than blanket-blocking the generic HA UA — previously every HA instance looked identical from their side.
- Verified live: `curl -A "HomeAssistant/2026.4.2 wiener_linien_austria/0.1.0" …/monitor` returns 200, so WL's server accepts the custom agent cleanly.

## Test plan
- [x] `python3 -m pytest tests/ -q` — 47/47 pass (new `test_fetch_sends_user_agent_header`)
- [x] `mypy --strict --ignore-missing-imports custom_components/wiener_linien_austria` — clean
- [x] `ruff check .` — clean
- [x] Confirmed WL endpoint 200 OK for the custom UA string

🤖 Generated with [Claude Code](https://claude.com/claude-code)