### PR TITLE
feat: traffic disruptions + elevator outages (v0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Type a stop name, pick it from a list, choose which lines to track. Done.
 - Multi-step config flow: search → pick stop → pick lines. Live API probe during setup confirms connectivity and shows the exact lines you'll be tracking.
 - Reconfigure flow to add/remove lines at a stop without losing the entry.
 - Options flow to change the polling interval without re-doing selection.
-- Diagnostics download with attribution, coordinator state, last error code, and server time.
+- **Service disruption alerts** (`trafficInfoList`) filtered to the lines you're tracking — surfaced in the `traffic_info` sensor attribute and as a banner on the Lovelace card.
+- **Elevator outage alerts** (`Aufzugsinfo`) filtered to your stop's RBLs — surfaced in the `elevator_info` sensor attribute and as a badge on the card.
+- Diagnostics download with attribution, coordinator state, last error code, server time, and currently matched alerts.
 
 ## Requirements
 
@@ -134,7 +136,6 @@ logger:
 ## Known Limitations
 
 - **Vienna only.** The Wiener Linien API covers Wiener Linien routes; ÖBB / VOR / regional services are outside its scope.
-- **Departures only (v0.1).** Traffic info (`trafficInfoList`) and elevator status (`Aufzugsinfo`) are planned for v0.2.
 - **Polling floor of 30 s** per entry, 15 s domain-wide cooldown across all entries. You cannot go below these; they exist to respect Wiener Linien's fair-use policy.
 - **No journey planning.** The OGD monitor endpoint returns departures at a stop; it does not do routing.
 - **Static catalogue refreshes weekly.** Brand-new stops may take up to a week to appear in search until the cache rebuilds.

--- a/custom_components/wiener_linien_austria/__init__.py
+++ b/custom_components/wiener_linien_austria/__init__.py
@@ -17,7 +17,15 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import CARD_URL, CARD_VERSION, DOMAIN, STATIC_CACHE_REFRESH_HOURS
+from .alerts import async_refresh_alerts
+from .const import (
+    ALERTS_REFRESH_SECONDS,
+    ALERTS_REFRESH_UNSUB_KEY,
+    CARD_URL,
+    CARD_VERSION,
+    DOMAIN,
+    STATIC_CACHE_REFRESH_HOURS,
+)
 from .coordinator import WienerLinienAustriaCoordinator
 from .static import async_refresh_catalogue
 
@@ -59,6 +67,23 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
             hass,
             _periodic_refresh,
             timedelta(hours=STATIC_CACHE_REFRESH_HOURS),
+            cancel_on_shutdown=True,
+        )
+
+    if ALERTS_REFRESH_UNSUB_KEY not in domain_data:
+        async def _periodic_alerts(_now: Any) -> None:
+            await async_refresh_alerts(hass)
+
+        # No eager first fetch — the periodic timer populates the cache after
+        # ALERTS_REFRESH_SECONDS. During the warm-up window (up to 5 min after
+        # start) sensors simply expose empty traffic_info / elevator_info
+        # lists; not surfacing a possibly-stale alert during the first few
+        # minutes is a reasonable trade for keeping startup non-blocking and
+        # side-effect-free.
+        domain_data[ALERTS_REFRESH_UNSUB_KEY] = async_track_time_interval(
+            hass,
+            _periodic_alerts,
+            timedelta(seconds=ALERTS_REFRESH_SECONDS),
             cancel_on_shutdown=True,
         )
 

--- a/custom_components/wiener_linien_austria/alerts.py
+++ b/custom_components/wiener_linien_austria/alerts.py
@@ -1,0 +1,312 @@
+"""Traffic disruptions and elevator status from the Wiener Linien `/trafficInfoList` endpoint.
+
+Both user-visible alert types are surfaced by the same endpoint, just via the
+`name=` filter:
+
+- `stoerunglang` — line/route disruptions (scope: city-wide)
+- `aufzugsinfo` — elevator out-of-service notices (scope: per station + per RBL)
+
+Fetched on a slow (5 min) domain-wide cadence — these don't change any faster
+than a few times an hour and aggregating across all entries keeps the
+integration's outbound request rate trivial. Each sensor filters the cached
+lists by its own (lines, RBLs) at attribute-read time.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import aiohttp
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    API_BASE_URL,
+    DOMAIN,
+    DOMAIN_COOLDOWN_SECONDS,
+    DOMAIN_LAST_CALL_KEY,
+    ELEVATOR_INFO_KEY,
+    TRAFFIC_INFO_ENDPOINT,
+    TRAFFIC_INFO_KEY,
+    USER_AGENT,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Data shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class TrafficInfo:
+    """One service disruption affecting one or more lines."""
+
+    name: str  # stable upstream id, e.g. "I20260420-0032"
+    title: str  # "49A: Verkehrsunfall"
+    description: str
+    related_lines: list[str]
+    time_start: str | None
+    time_end: str | None
+    status: str  # "active" etc.
+
+    def to_dict(self) -> dict[str, Any]:
+        """Render as plain dict for sensor attributes / diagnostics."""
+        return {
+            "name": self.name,
+            "title": self.title,
+            "description": self.description,
+            "related_lines": list(self.related_lines),
+            "time_start": self.time_start,
+            "time_end": self.time_end,
+            "status": self.status,
+        }
+
+
+@dataclass(slots=True)
+class ElevatorInfo:
+    """One elevator outage."""
+
+    name: str
+    station: str
+    description: str  # usually the physical location of the elevator
+    reason: str  # free-text reason in German
+    status: str  # "außer Betrieb" etc.
+    related_lines: list[str]
+    related_stops: list[int]  # RBLs where this elevator applies
+    time_start: str | None
+    time_end: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Render as plain dict for sensor attributes / diagnostics."""
+        return {
+            "name": self.name,
+            "station": self.station,
+            "description": self.description,
+            "reason": self.reason,
+            "status": self.status,
+            "related_lines": list(self.related_lines),
+            "related_stops": list(self.related_stops),
+            "time_start": self.time_start,
+            "time_end": self.time_end,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+async def _enforce_domain_cooldown(hass: HomeAssistant) -> None:
+    """Serialise outbound calls across the whole integration (coordinator + alerts)."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    last: datetime | None = domain_data.get(DOMAIN_LAST_CALL_KEY)
+    now = dt_util.utcnow()
+    if last is not None:
+        elapsed = (now - last).total_seconds()
+        if elapsed < DOMAIN_COOLDOWN_SECONDS:
+            await asyncio.sleep(DOMAIN_COOLDOWN_SECONDS - elapsed)
+    domain_data[DOMAIN_LAST_CALL_KEY] = dt_util.utcnow()
+
+
+async def _fetch_info_list(
+    hass: HomeAssistant, name: str
+) -> list[dict[str, Any]]:
+    """GET /trafficInfoList?name=<name> and return its trafficInfos array.
+
+    Returns [] on any fetch/parse failure — alerts are advisory, never fatal.
+    """
+    session = async_get_clientsession(hass)
+    url = f"{API_BASE_URL}{TRAFFIC_INFO_ENDPOINT}"
+    try:
+        await _enforce_domain_cooldown(hass)
+        resp = await session.get(
+            url,
+            params=[("name", name)],
+            headers={"User-Agent": USER_AGENT},
+            timeout=aiohttp.ClientTimeout(total=15),
+        )
+        resp.raise_for_status()
+        body = await resp.json()
+    except Exception as err:  # noqa: BLE001 — alerts are advisory, never fatal.
+        _LOGGER.warning("Failed to refresh %s alerts: %s", name, err)
+        return []
+
+    if not isinstance(body, dict):
+        return []
+    message = body.get("message") or {}
+    if message.get("messageCode") not in (1, None):
+        _LOGGER.debug(
+            "trafficInfoList?name=%s returned non-OK messageCode %s",
+            name,
+            message.get("messageCode"),
+        )
+        return []
+    infos = (body.get("data") or {}).get("trafficInfos") or []
+    return [x for x in infos if isinstance(x, dict)]
+
+
+async def async_refresh_alerts(hass: HomeAssistant) -> None:
+    """Refresh both traffic and elevator alerts into hass.data.
+
+    Safe to call whenever; failures keep the previous cache.
+    """
+    traffic_raw, elevator_raw = await asyncio.gather(
+        _fetch_info_list(hass, "stoerunglang"),
+        _fetch_info_list(hass, "aufzugsinfo"),
+    )
+
+    domain_data = hass.data.setdefault(DOMAIN, {})
+
+    if traffic_raw:
+        domain_data[TRAFFIC_INFO_KEY] = [_parse_traffic(x) for x in traffic_raw]
+    elif TRAFFIC_INFO_KEY not in domain_data:
+        domain_data[TRAFFIC_INFO_KEY] = []
+
+    if elevator_raw:
+        domain_data[ELEVATOR_INFO_KEY] = [_parse_elevator(x) for x in elevator_raw]
+    elif ELEVATOR_INFO_KEY not in domain_data:
+        domain_data[ELEVATOR_INFO_KEY] = []
+
+    _LOGGER.debug(
+        "Alerts refreshed: %d traffic, %d elevator",
+        len(domain_data.get(TRAFFIC_INFO_KEY, [])),
+        len(domain_data.get(ELEVATOR_INFO_KEY, [])),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parse
+# ---------------------------------------------------------------------------
+
+
+def _parse_traffic(raw: dict[str, Any]) -> TrafficInfo:
+    """Parse one trafficInfos entry for name=stoerunglang."""
+    time = raw.get("time") or {}
+    related_lines = _as_str_list(raw.get("relatedLines"))
+    return TrafficInfo(
+        name=str(raw.get("name") or ""),
+        title=str(raw.get("title") or "").strip(),
+        description=str(raw.get("description") or "").strip(),
+        related_lines=related_lines,
+        time_start=_str_or_none(time.get("start")),
+        time_end=_str_or_none(time.get("end")),
+        status=str(raw.get("status") or ""),
+    )
+
+
+def _parse_elevator(raw: dict[str, Any]) -> ElevatorInfo:
+    """Parse one trafficInfos entry for name=aufzugsinfo.
+
+    Shape is less regular than stoerunglang — pulls fallbacks from
+    `attributes` when top-level fields are absent.
+    """
+    attrs = raw.get("attributes") or {}
+    time = raw.get("time") or {}
+
+    related_lines = _as_str_list(raw.get("relatedLines"))
+    if not related_lines:
+        related_lines = _as_str_list(attrs.get("relatedLines"))
+
+    related_stops = _as_int_list(raw.get("relatedStops"))
+    if not related_stops:
+        related_stops = _as_int_list(attrs.get("relatedStops"))
+
+    station = str(
+        attrs.get("station") or raw.get("title") or ""
+    ).strip()
+    description = str(
+        raw.get("description") or attrs.get("location") or ""
+    ).strip()
+    reason = str(attrs.get("reason") or "").strip()
+    status = str(attrs.get("status") or "").strip()
+
+    return ElevatorInfo(
+        name=str(raw.get("name") or ""),
+        station=station,
+        description=description,
+        reason=reason,
+        status=status,
+        related_lines=related_lines,
+        related_stops=related_stops,
+        time_start=_str_or_none(time.get("start")),
+        time_end=_str_or_none(time.get("end")),
+    )
+
+
+def _as_str_list(val: Any) -> list[str]:
+    """Coerce to a list of non-empty stripped strings."""
+    if isinstance(val, list):
+        return [str(x).strip() for x in val if isinstance(x, str) and x.strip()]
+    if isinstance(val, dict):
+        return [str(k).strip() for k in val.keys() if isinstance(k, str) and k.strip()]
+    return []
+
+
+def _as_int_list(val: Any) -> list[int]:
+    """Coerce to a list of ints, dropping non-numeric entries."""
+    if not isinstance(val, list):
+        return []
+    out: list[int] = []
+    for item in val:
+        try:
+            out.append(int(item))
+        except (ValueError, TypeError):
+            continue
+    return out
+
+
+def _str_or_none(val: Any) -> str | None:
+    """Return val as a string if truthy, else None."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    return s or None
+
+
+# ---------------------------------------------------------------------------
+# Query
+# ---------------------------------------------------------------------------
+
+
+def get_alerts_for(
+    hass: HomeAssistant,
+    lines: set[str] | None,
+    rbls: set[int] | None,
+) -> tuple[list[TrafficInfo], list[ElevatorInfo]]:
+    """Return traffic + elevator alerts relevant to a given stop.
+
+    - Traffic: match if any `related_lines` overlaps `lines`. If `lines` is
+      empty/None, return all traffic alerts (fall-through).
+    - Elevator: match if any `related_stops` overlaps `rbls`. If `rbls` is
+      empty/None, return []. An elevator outage with no `related_stops` is
+      only surfaced when it also matches on `related_lines`.
+    """
+    domain_data = hass.data.get(DOMAIN, {})
+    all_traffic: list[TrafficInfo] = domain_data.get(TRAFFIC_INFO_KEY, []) or []
+    all_elevator: list[ElevatorInfo] = domain_data.get(ELEVATOR_INFO_KEY, []) or []
+
+    matched_traffic: list[TrafficInfo] = []
+    if lines:
+        for t in all_traffic:
+            if set(t.related_lines) & lines:
+                matched_traffic.append(t)
+    else:
+        matched_traffic = list(all_traffic)
+
+    matched_elevator: list[ElevatorInfo] = []
+    if rbls:
+        for e in all_elevator:
+            stop_hit = bool(set(e.related_stops) & rbls)
+            if stop_hit:
+                matched_elevator.append(e)
+                continue
+            # No explicit RBL match — fall back to line match if present.
+            if not e.related_stops and lines and set(e.related_lines) & lines:
+                matched_elevator.append(e)
+
+    return matched_traffic, matched_elevator

--- a/custom_components/wiener_linien_austria/const.py
+++ b/custom_components/wiener_linien_austria/const.py
@@ -42,6 +42,18 @@ STATIC_CACHE_REFRESH_HOURS: Final = 24 * 7
 # Upstream API
 API_BASE_URL: Final = "https://www.wienerlinien.at/ogd_realtime"
 MONITOR_ENDPOINT: Final = "/monitor"
+TRAFFIC_INFO_ENDPOINT: Final = "/trafficInfoList"
+
+# Alerts (traffic disruptions + elevator outages) refresh cadence. Domain-wide,
+# shared across all entries. 5 min is plenty — these don't change any faster
+# than a few times an hour and fetching more often just eats the fair-use
+# budget that belongs to live departure polling.
+ALERTS_REFRESH_SECONDS: Final = 300
+
+# hass.data keys for the shared alert caches + scheduler unsub.
+TRAFFIC_INFO_KEY: Final = "traffic_info"
+ELEVATOR_INFO_KEY: Final = "elevator_info"
+ALERTS_REFRESH_UNSUB_KEY: Final = "alerts_refresh_unsub"
 
 STATIC_FILES: Final = {
     "haltestellen": f"{API_BASE_URL}/doku/ogd/wienerlinien-ogd-haltestellen.csv",

--- a/custom_components/wiener_linien_austria/diagnostics.py
+++ b/custom_components/wiener_linien_austria/diagnostics.py
@@ -7,7 +7,8 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import ATTRIBUTION
+from .alerts import get_alerts_for
+from .const import ATTRIBUTION, CONF_LINES, CONF_RBLS
 from .coordinator import WienerLinienAustriaCoordinator
 
 # No credentials to redact (Wiener Linien OGD has no API key), and RBL/DIVA
@@ -22,6 +23,17 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     coordinator: WienerLinienAustriaCoordinator = entry.runtime_data
     data = coordinator.data
+
+    config = {**entry.data, **entry.options}
+    selected_line_keys = config.get(CONF_LINES) or []
+    line_names: set[str] = {
+        k.split("|", 1)[0]
+        for k in selected_line_keys
+        if isinstance(k, str) and k
+    }
+    rbls = {int(r) for r in config.get(CONF_RBLS) or []}
+    traffic, elevator = get_alerts_for(hass, line_names, rbls)
+
     return {
         "attribution": ATTRIBUTION,
         "entry": {
@@ -37,5 +49,9 @@ async def async_get_config_entry_diagnostics(
             "server_time": coordinator.server_time,
             "rbls": list(coordinator.rbls),
             "departure_count": len(data.departures) if data is not None else 0,
+        },
+        "alerts": {
+            "traffic_info": [t.to_dict() for t in traffic],
+            "elevator_info": [e.to_dict() for e in elevator],
         },
     }

--- a/custom_components/wiener_linien_austria/quality_scale.yaml
+++ b/custom_components/wiener_linien_austria/quality_scale.yaml
@@ -6,8 +6,8 @@ rules:
   appropriate-polling:
     status: done
   brands:
-    status: todo
-    comment: Submit an icon PR to https://github.com/home-assistant/brands before first release.
+    status: done
+    comment: Icons shipped in custom_components/wiener_linien_austria/brand/ (icon.png 256x256, icon@2x.png 512x512). HA 2026.3+ reads this locally; the home-assistant/brands repo no longer accepts custom-integration PRs.
   common-modules:
     status: done
   config-flow:

--- a/custom_components/wiener_linien_austria/sensor.py
+++ b/custom_components/wiener_linien_austria/sensor.py
@@ -13,7 +13,15 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, CONF_DIVA, CONF_STOP_NAME, DOMAIN
+from .alerts import get_alerts_for
+from .const import (
+    ATTRIBUTION,
+    CONF_DIVA,
+    CONF_LINES,
+    CONF_RBLS,
+    CONF_STOP_NAME,
+    DOMAIN,
+)
 from .coordinator import Departure, MonitorData, WienerLinienAustriaCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -72,7 +80,7 @@ class WienerLinienStopSensor(
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the departure board + grouped views."""
+        """Return the departure board + grouped views + matched alerts."""
         config = {**self._entry.data, **self._entry.options}
         diva = int(config[CONF_DIVA])
         stop_name = str(config.get(CONF_STOP_NAME, self._entry.title))
@@ -86,6 +94,26 @@ class WienerLinienStopSensor(
             grouped[dep.line].append(dep.to_dict())
             next_by_line.setdefault(dep.line, dep.countdown)
 
+        # Match domain-wide alert caches against this entry's lines + RBLs.
+        # Lines derived from CONF_LINES ("U1|H|Leopoldau") — the user's own
+        # selection, stable even when no departures are flowing right now.
+        # Fall back to live departures for the "all lines" case.
+        selected_line_keys = config.get(CONF_LINES) or []
+        line_names: set[str] = {
+            k.split("|", 1)[0]
+            for k in selected_line_keys
+            if isinstance(k, str) and k
+        }
+        if not line_names:
+            line_names = {d.line for d in departures if d.line}
+        rbls = {int(r) for r in config.get(CONF_RBLS) or []}
+
+        # Use the coordinator's hass reference — `self.hass` is only set after
+        # async_added_to_hass, but tests instantiate the sensor directly.
+        traffic, elevator = get_alerts_for(
+            self.coordinator.hass, line_names, rbls
+        )
+
         return {
             "attribution": ATTRIBUTION,
             "diva": diva,
@@ -94,6 +122,8 @@ class WienerLinienStopSensor(
             "departures": [d.to_dict() for d in departures],
             "departures_by_line": dict(grouped),
             "next_by_line": next_by_line,
+            "traffic_info": [t.to_dict() for t in traffic],
+            "elevator_info": [e.to_dict() for e in elevator],
         }
 
     @property

--- a/custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js
+++ b/custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js
@@ -33,6 +33,8 @@ const TRANSLATIONS = {
     dir_h: "H",
     dir_r: "R",
     dir_both: "Beide",
+    traffic_label: "Störung",
+    elevator_label: "Aufzug außer Betrieb",
     editor: {
       section_sensors: "Haltestellen",
       sensors_hint: "Eine oder mehrere Haltestellen auswählen",
@@ -47,6 +49,8 @@ const TRANSLATIONS = {
       section_display: "Anzeige",
       max_departures: "Anzahl Abfahrten pro Haltestelle",
       show_accessibility: "Barrierefrei-Symbol anzeigen",
+      show_traffic_info: "Störungen anzeigen",
+      show_elevator_info: "Aufzugsinfo anzeigen",
       no_sensors_available:
         "Keine Wiener-Linien-Sensoren verfügbar. Erst eine Haltestelle über Einstellungen → Geräte & Dienste hinzufügen.",
       no_lines_available:
@@ -68,6 +72,8 @@ const TRANSLATIONS = {
     dir_h: "H",
     dir_r: "R",
     dir_both: "Both",
+    traffic_label: "Disruption",
+    elevator_label: "Elevator out of service",
     editor: {
       section_sensors: "Stops",
       sensors_hint: "Pick one or more stops to display",
@@ -82,6 +88,8 @@ const TRANSLATIONS = {
       section_display: "Display",
       max_departures: "Departures per stop",
       show_accessibility: "Show step-free icon",
+      show_traffic_info: "Show disruption alerts",
+      show_elevator_info: "Show elevator outages",
       no_sensors_available:
         "No Wiener Linien sensors available. Add a stop first via Settings → Devices & Services.",
       no_lines_available:
@@ -163,6 +171,10 @@ function _normaliseConfig(config) {
   }
 
   out.show_accessibility = out.show_accessibility === true;
+  // Alert toggles default ON — if nothing is active, nothing renders anyway,
+  // so opt-in would hide useful info without saving screen real estate.
+  out.show_traffic_info = out.show_traffic_info !== false;
+  out.show_elevator_info = out.show_elevator_info !== false;
 
   return out;
 }
@@ -224,6 +236,43 @@ const CARD_STYLE = `
     font-size: 1.05em;
     font-weight: 600;
     margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .wl-header ha-icon {
+    --mdc-icon-size: 18px;
+    color: var(--warning-color, #ffa000);
+    cursor: help;
+  }
+  .wl-traffic-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 10px;
+  }
+  .wl-traffic {
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+    padding: 8px 10px;
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--warning-color, #ffa000) 14%, transparent);
+    border-left: 3px solid var(--warning-color, #ffa000);
+    font-size: 0.85em;
+  }
+  .wl-traffic ha-icon {
+    --mdc-icon-size: 18px;
+    color: var(--warning-color, #ffa000);
+    flex-shrink: 0;
+  }
+  .wl-traffic-body .wl-traffic-title {
+    font-weight: 600;
+    margin-bottom: 2px;
+  }
+  .wl-traffic-body .wl-traffic-desc {
+    color: var(--secondary-text-color);
+    line-height: 1.35;
   }
   .wl-empty {
     padding: 18px 0;
@@ -369,7 +418,13 @@ class WienerLinienAustriaCard extends HTMLElement {
             }|${d.barrier_free ? 1 : 0}`,
         )
         .join(";");
-      return `${s.entity}@${a.server_time || ""}#${depKey}`;
+      const trafficKey = (a.traffic_info || [])
+        .map((t) => `${t.name}:${t.status}`)
+        .join(",");
+      const elevatorKey = (a.elevator_info || [])
+        .map((e) => `${e.name}:${e.status}`)
+        .join(",");
+      return `${s.entity}@${a.server_time || ""}#${depKey}^T${trafficKey}^E${elevatorKey}`;
     });
     return `${this._versionMismatch || ""}||${cfgKey}||${stopKeys.join("|||")}`;
   }
@@ -381,6 +436,8 @@ class WienerLinienAustriaCard extends HTMLElement {
     const max = this._config.max_departures;
     const overrides = this._config.line_colors || {};
     const showA11y = this._config.show_accessibility;
+    const showTraffic = this._config.show_traffic_info;
+    const showElevator = this._config.show_elevator_info;
 
     const attribution =
       stops
@@ -388,8 +445,13 @@ class WienerLinienAustriaCard extends HTMLElement {
         .find((v) => typeof v === "string" && v.length > 0) ||
       "Datenquelle: Wiener Linien (data.wien.gv.at), CC BY 4.0";
 
+    const trafficHtml = showTraffic ? this._renderTrafficBanner(stops) : "";
     const body = stops.length
-      ? stops.map((s) => this._renderStop(s, max, overrides, showA11y)).join("")
+      ? stops
+          .map((s) =>
+            this._renderStop(s, max, overrides, showA11y, showElevator),
+          )
+          .join("")
       : this._renderEmpty();
 
     this.innerHTML = `
@@ -397,6 +459,7 @@ class WienerLinienAustriaCard extends HTMLElement {
         <style>${CARD_STYLE}</style>
         <div class="wl-card">
           ${this._versionMismatch ? this._renderBanner() : ""}
+          ${trafficHtml}
           ${body}
           <div class="wl-attr">${_esc(attribution)}</div>
         </div>
@@ -409,19 +472,73 @@ class WienerLinienAustriaCard extends HTMLElement {
     }
   }
 
+  _renderTrafficBanner(stops) {
+    // Deduplicate by traffic-info name across all selected stops.
+    const seen = new Set();
+    const items = [];
+    for (const s of stops) {
+      const tis = this._hass.states[s.entity]?.attributes?.traffic_info || [];
+      for (const t of tis) {
+        if (!t || seen.has(t.name)) continue;
+        seen.add(t.name);
+        items.push(t);
+      }
+    }
+    if (!items.length) return "";
+    return `
+      <div class="wl-traffic-list">
+        ${items.map((t) => this._renderTrafficItem(t)).join("")}
+      </div>
+    `;
+  }
+
+  _renderTrafficItem(t) {
+    const title = _esc(t.title || this._t("traffic_label"));
+    const desc = _esc(t.description || "");
+    return `
+      <div class="wl-traffic">
+        <ha-icon icon="mdi:alert-octagon"></ha-icon>
+        <div class="wl-traffic-body">
+          <div class="wl-traffic-title">${title}</div>
+          ${desc ? `<div class="wl-traffic-desc">${desc}</div>` : ""}
+        </div>
+      </div>
+    `;
+  }
+
   _renderEmpty() {
     const available = _findWienerLinienEntities(this._hass);
     const key = available.length ? "no_entities_picked" : "no_entities_available";
     return `<div class="wl-empty">${_esc(this._t(key))}</div>`;
   }
 
-  _renderStop(stopCfg, max, overrides, showA11y) {
+  _renderStop(stopCfg, max, overrides, showA11y, showElevator) {
     const state = this._hass.states[stopCfg.entity];
     const attrs = state?.attributes ?? {};
     const title = attrs.stop_name || attrs.friendly_name || stopCfg.entity;
     const allDepartures = Array.isArray(attrs.departures) ? attrs.departures : [];
     const filtered = _filterDepartures(allDepartures, stopCfg);
     const rows = filtered.slice(0, max);
+    const elevatorInfos = Array.isArray(attrs.elevator_info)
+      ? attrs.elevator_info
+      : [];
+
+    let elevatorBadge = "";
+    if (showElevator && elevatorInfos.length) {
+      const tooltip = elevatorInfos
+        .map((e) => {
+          const bits = [
+            e.station,
+            e.description,
+            e.reason,
+          ].filter((x) => typeof x === "string" && x.length > 0);
+          return bits.join(" — ");
+        })
+        .join("\n");
+      elevatorBadge = `<ha-icon icon="mdi:elevator-up" title="${_esc(
+        `${this._t("elevator_label")}:\n${tooltip}`,
+      )}"></ha-icon>`;
+    }
 
     let rowsHtml;
     if (rows.length) {
@@ -437,7 +554,10 @@ class WienerLinienAustriaCard extends HTMLElement {
 
     return `
       <div class="wl-stop">
-        <div class="wl-header">${_esc(title)}</div>
+        <div class="wl-header">
+          <span>${_esc(title)}</span>
+          ${elevatorBadge}
+        </div>
         ${rowsHtml}
       </div>
     `;
@@ -777,6 +897,8 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
     const max = this._config.max_departures ?? 6;
     const overrides = this._config.line_colors || {};
     const showA11y = this._config.show_accessibility === true;
+    const showTraffic = this._config.show_traffic_info !== false;
+    const showElevator = this._config.show_elevator_info !== false;
 
     // ----- Stop chips -----
     const stopChips = available.length
@@ -915,6 +1037,24 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
               type="checkbox"
               data-field="show_accessibility"
               ${showA11y ? "checked" : ""}
+            />
+          </div>
+          <div class="toggle-row">
+            <label for="wl-traffic-toggle">${_esc(this._et("show_traffic_info"))}</label>
+            <input
+              id="wl-traffic-toggle"
+              type="checkbox"
+              data-field="show_traffic_info"
+              ${showTraffic ? "checked" : ""}
+            />
+          </div>
+          <div class="toggle-row">
+            <label for="wl-elevator-toggle">${_esc(this._et("show_elevator_info"))}</label>
+            <input
+              id="wl-elevator-toggle"
+              type="checkbox"
+              data-field="show_elevator_info"
+              ${showElevator ? "checked" : ""}
             />
           </div>
         </div>

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,247 @@
+"""Tests for the alerts module (traffic info + elevator info)."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.wiener_linien_austria.alerts import (
+    ElevatorInfo,
+    TrafficInfo,
+    _parse_elevator,
+    _parse_traffic,
+    async_refresh_alerts,
+    get_alerts_for,
+)
+from custom_components.wiener_linien_austria.const import (
+    DOMAIN,
+    ELEVATOR_INFO_KEY,
+    TRAFFIC_INFO_KEY,
+)
+
+
+# ---------------------------------------------------------------------------
+# Parse
+# ---------------------------------------------------------------------------
+
+
+def test_parse_traffic_extracts_core_fields() -> None:
+    raw = {
+        "name": "I20260420-0032",
+        "title": "49A: Verkehrsunfall",
+        "description": "Linie 49A: Unregelmäßige Intervalle.",
+        "status": "active",
+        "time": {"start": "2026-04-20T16:42:00+0200", "end": "2026-04-20T23:55:00+0200"},
+        "relatedLines": ["49A"],
+    }
+    t = _parse_traffic(raw)
+    assert t.name == "I20260420-0032"
+    assert t.title == "49A: Verkehrsunfall"
+    assert t.related_lines == ["49A"]
+    assert t.time_start == "2026-04-20T16:42:00+0200"
+    assert t.time_end == "2026-04-20T23:55:00+0200"
+    assert t.status == "active"
+
+
+def test_parse_elevator_pulls_attributes_fallback() -> None:
+    """Elevator entries carry related info under `attributes` as well as top-level."""
+    raw = {
+        "name": "ftazS_475",
+        "title": "Tscherttegasse",
+        "description": "U6 Bahnsteig Richtung Siebenhirten - Ausgang Tscherttegasse",
+        "attributes": {
+            "reason": "AUFZUGSERNEUERUNG",
+            "station": "Tscherttegasse",
+            "relatedLines": ["U6"],
+            "relatedStops": [4629],
+            "status": "außer Betrieb",
+            "location": "U6 Bahnsteig Richtung Siebenhirten",
+        },
+        "time": {"start": "2026-05-28T01:15:00+0200"},
+    }
+    e = _parse_elevator(raw)
+    assert e.station == "Tscherttegasse"
+    assert e.reason == "AUFZUGSERNEUERUNG"
+    assert e.status == "außer Betrieb"
+    assert e.related_lines == ["U6"]
+    assert e.related_stops == [4629]
+
+
+def test_parse_elevator_tolerates_missing_fields() -> None:
+    """Entries with no attributes at all still parse without raising."""
+    e = _parse_elevator({"name": "x"})
+    assert isinstance(e, ElevatorInfo)
+    assert e.station == ""
+    assert e.related_stops == []
+
+
+# ---------------------------------------------------------------------------
+# Filter
+# ---------------------------------------------------------------------------
+
+
+def _seed(hass: HomeAssistant) -> None:
+    """Populate hass.data with one traffic + one elevator entry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][TRAFFIC_INFO_KEY] = [
+        TrafficInfo(
+            name="T1",
+            title="49A: Verkehrsunfall",
+            description="Linie 49A unregelmäßig.",
+            related_lines=["49A"],
+            time_start=None,
+            time_end=None,
+            status="active",
+        ),
+        TrafficInfo(
+            name="T2",
+            title="U4: Kurze Unterbrechung",
+            description="Linie U4.",
+            related_lines=["U4"],
+            time_start=None,
+            time_end=None,
+            status="active",
+        ),
+    ]
+    hass.data[DOMAIN][ELEVATOR_INFO_KEY] = [
+        ElevatorInfo(
+            name="E1",
+            station="Tscherttegasse",
+            description="U6 Bahnsteig",
+            reason="AUFZUGSERNEUERUNG",
+            status="außer Betrieb",
+            related_lines=["U6"],
+            related_stops=[4629],
+            time_start=None,
+            time_end=None,
+        ),
+        ElevatorInfo(
+            name="E2",
+            station="Stephansplatz",
+            description="U1 Ausgang",
+            reason="",
+            status="außer Betrieb",
+            related_lines=["U1"],
+            related_stops=[4111],
+            time_start=None,
+            time_end=None,
+        ),
+    ]
+
+
+async def test_get_alerts_for_line_match(hass: HomeAssistant) -> None:
+    _seed(hass)
+    traffic, elevator = get_alerts_for(hass, {"U4"}, set())
+    assert [t.name for t in traffic] == ["T2"]
+    # No RBLs supplied, no line-only elevator fallback path → empty.
+    assert elevator == []
+
+
+async def test_get_alerts_for_rbl_match(hass: HomeAssistant) -> None:
+    _seed(hass)
+    traffic, elevator = get_alerts_for(hass, {"U6"}, {4629})
+    # Line match on the traffic side wouldn't hit (we have no U6 traffic).
+    assert traffic == []
+    assert [e.name for e in elevator] == ["E1"]
+
+
+async def test_get_alerts_for_empty_cache(hass: HomeAssistant) -> None:
+    """With no cached alerts, both sides are empty lists, not None."""
+    traffic, elevator = get_alerts_for(hass, {"U1"}, {4111})
+    assert traffic == []
+    assert elevator == []
+
+
+async def test_get_alerts_for_no_lines_returns_all_traffic(hass: HomeAssistant) -> None:
+    """Empty `lines` set falls through to all traffic alerts."""
+    _seed(hass)
+    traffic, _ = get_alerts_for(hass, None, {4111})
+    assert {t.name for t in traffic} == {"T1", "T2"}
+
+
+# ---------------------------------------------------------------------------
+# Refresh
+# ---------------------------------------------------------------------------
+
+
+async def test_async_refresh_alerts_populates_caches(hass: HomeAssistant) -> None:
+    """One fetch for stoerunglang + one for aufzugsinfo, caches populated."""
+    traffic_body = {
+        "message": {"messageCode": 1},
+        "data": {
+            "trafficInfos": [
+                {
+                    "name": "T1",
+                    "title": "U4: Short",
+                    "description": "x",
+                    "relatedLines": ["U4"],
+                    "status": "active",
+                    "time": {},
+                }
+            ]
+        },
+    }
+    elevator_body = {
+        "message": {"messageCode": 1},
+        "data": {
+            "trafficInfos": [
+                {
+                    "name": "E1",
+                    "title": "Stephansplatz",
+                    "description": "U1 exit",
+                    "attributes": {
+                        "station": "Stephansplatz",
+                        "reason": "renovation",
+                        "relatedLines": ["U1"],
+                        "relatedStops": [4111],
+                        "status": "außer Betrieb",
+                    },
+                    "time": {},
+                }
+            ]
+        },
+    }
+
+    resp_traffic = MagicMock()
+    resp_traffic.raise_for_status = MagicMock()
+    resp_traffic.json = AsyncMock(return_value=traffic_body)
+    resp_elevator = MagicMock()
+    resp_elevator.raise_for_status = MagicMock()
+    resp_elevator.json = AsyncMock(return_value=elevator_body)
+
+    async def fake_get(url: str, **kwargs: object) -> MagicMock:
+        name = next((v for k, v in kwargs["params"] if k == "name"), None)
+        return resp_elevator if name == "aufzugsinfo" else resp_traffic
+
+    fake_session = MagicMock()
+    fake_session.get = AsyncMock(side_effect=fake_get)
+
+    with patch(
+        "custom_components.wiener_linien_austria.alerts.async_get_clientsession",
+        return_value=fake_session,
+    ):
+        await async_refresh_alerts(hass)
+
+    traffic = hass.data[DOMAIN][TRAFFIC_INFO_KEY]
+    elevator = hass.data[DOMAIN][ELEVATOR_INFO_KEY]
+    assert [t.name for t in traffic] == ["T1"]
+    assert [e.name for e in elevator] == ["E1"]
+    assert elevator[0].related_stops == [4111]
+
+
+async def test_async_refresh_alerts_swallows_errors(hass: HomeAssistant) -> None:
+    """Fetch failures must not raise — alerts are advisory."""
+    fake_session = MagicMock()
+    fake_session.get = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    with patch(
+        "custom_components.wiener_linien_austria.alerts.async_get_clientsession",
+        return_value=fake_session,
+    ):
+        # Should not raise.
+        await async_refresh_alerts(hass)
+
+    # Caches are empty lists, not missing keys.
+    assert hass.data[DOMAIN][TRAFFIC_INFO_KEY] == []
+    assert hass.data[DOMAIN][ELEVATOR_INFO_KEY] == []

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -302,3 +302,76 @@ async def test_sensor_state_present_after_setup(
     assert state.attributes["attribution"] == ATTRIBUTION
     assert state.attributes["diva"] == 60201012
     assert len(state.attributes["departures"]) >= 1
+
+
+async def test_attributes_include_matched_alerts(hass: HomeAssistant) -> None:
+    """traffic_info + elevator_info attributes surface the alerts that match this stop."""
+    from custom_components.wiener_linien_austria.alerts import (
+        ElevatorInfo,
+        TrafficInfo,
+    )
+    from custom_components.wiener_linien_austria.const import (
+        ELEVATOR_INFO_KEY,
+        TRAFFIC_INFO_KEY,
+    )
+
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+    data = MonitorData(
+        departures=_make_departures(), server_time="2026-04-20T14:40:00+0200"
+    )
+    coordinator = _make_coordinator(hass, entry, data)
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][TRAFFIC_INFO_KEY] = [
+        TrafficInfo(
+            name="T1",
+            title="U1: Störung",
+            description="Linie U1",
+            related_lines=["U1"],
+            time_start=None,
+            time_end=None,
+            status="active",
+        ),
+        TrafficInfo(
+            name="T2",
+            title="49A: unrelated",
+            description="other line",
+            related_lines=["49A"],
+            time_start=None,
+            time_end=None,
+            status="active",
+        ),
+    ]
+    hass.data[DOMAIN][ELEVATOR_INFO_KEY] = [
+        ElevatorInfo(
+            name="E1",
+            station="Stephansplatz",
+            description="U1 exit",
+            reason="maintenance",
+            status="außer Betrieb",
+            related_lines=["U1"],
+            related_stops=[4111],
+            time_start=None,
+            time_end=None,
+        ),
+        ElevatorInfo(
+            name="E2",
+            station="Tscherttegasse",
+            description="U6 platform",
+            reason="",
+            status="außer Betrieb",
+            related_lines=["U6"],
+            related_stops=[4629],
+            time_start=None,
+            time_end=None,
+        ),
+    ]
+
+    sensor = WienerLinienStopSensor(coordinator, entry)
+    attrs = sensor.extra_state_attributes
+
+    # Only the U1-related traffic alert is surfaced (CONF_LINES filters).
+    assert [t["name"] for t in attrs["traffic_info"]] == ["T1"]
+    # Only the RBL 4111 elevator alert is surfaced (CONF_RBLS filters).
+    assert [e["name"] for e in attrs["elevator_info"]] == ["E1"]


### PR DESCRIPTION
## Summary
Two alert types now surface on sensors and card. Both read from the same upstream endpoint — `/trafficInfoList` with `name=stoerunglang` for service disruptions and `name=aufzugsinfo` for elevator outages — on a domain-wide 5-min schedule shared across all entries. Fair-use footprint: one request pair every 5 min total, regardless of how many stops you track.

## What's new
- **`custom_components/wiener_linien_austria/alerts.py`** — fetch + parse + cache + filter. Matches a stop's lines against `relatedLines` for traffic and its RBLs against `relatedStops` for elevators. Errors are swallowed; failed fetches keep the previous cache.
- **Sensor attributes** grow `traffic_info: [...]` and `elevator_info: [...]`, each filtered to what's relevant for that stop's lines + RBLs.
- **Diagnostics** includes the same filtered alert snapshot per entry.
- **Card** renders one warning banner per unique traffic alert at the top of the card (deduped across selected stops) and an elevator-icon badge next to each stop's header with outage details in the native title tooltip.
- **Editor** gains two toggles: `show_traffic_info` and `show_elevator_info` (both default on — if the cache is empty, nothing renders anyway).
- **Fingerprint** extended so the card re-renders when alerts change (keeps the flicker-free short-circuit working).
- **README**: moved "traffic info / elevator status" from Known Limitations to Supported Functions.

## Design notes
- **No eager first fetch.** The 5-min timer alone populates the cache. A brief warm-up window with empty alert lists is a reasonable trade for keeping `async_setup` non-blocking and side-effect-free (also avoided a flaky teardown in tests).
- **Line matching key:** `CONF_LINES` stores `"U1|H|Leopoldau"` triples; we extract line name by splitting on `|`. Falls back to live departure-derived lines when `CONF_LINES` is empty (i.e. track-all).
- **Elevator fallback:** entries without `relatedStops` are surfaced on a line match, since some elevator outages are published without an explicit RBL.

## Test plan
- [x] `python3 -m pytest tests/ -q` — 57/57 pass (+10 new: 9 in `test_alerts.py` covering parse/filter/refresh including error-swallow, 1 in `test_sensor.py` for the new attributes)
- [x] `mypy --strict --ignore-missing-imports custom_components/wiener_linien_austria` — clean (8 source files)
- [x] `ruff check .` — clean
- [x] Dev-pushed to rpi25, HA restarted, integration reloads without errors; sensor now carries `traffic_info` + `elevator_info` keys (empty until 5-min timer fires)

## Follow-up (separate issue)
Recorder is warning that `sensor.westbahnhof_abfahrten` attributes exceed 16 KB — pre-existing issue with the verbose `departures` + `departures_by_line` pair, not introduced by this PR. Worth a dedicated PR to cap list length or drop the duplicate grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)