### PR TITLE
fix: drop departures_by_line — duplicated payload blew past 16 KB recorder cap

### DIFF
--- a/custom_components/wiener_linien_austria/sensor.py
+++ b/custom_components/wiener_linien_austria/sensor.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
 from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
@@ -88,10 +87,14 @@ class WienerLinienStopSensor(
         data: MonitorData | None = self.coordinator.data
         departures = data.departures if data is not None else []
 
-        grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        # next_by_line is a tiny per-line → int map for cheap template access.
+        # We deliberately don't publish a full `departures_by_line` grouping
+        # because it would duplicate every departure dict under `departures`,
+        # doubling attribute size and tripping the recorder's 16 KB limit at
+        # busy stops. Consumers that need a grouped view can reduce over
+        # `departures` themselves.
         next_by_line: dict[str, int] = {}
         for dep in departures:
-            grouped[dep.line].append(dep.to_dict())
             next_by_line.setdefault(dep.line, dep.countdown)
 
         # Match domain-wide alert caches against this entry's lines + RBLs.
@@ -120,7 +123,6 @@ class WienerLinienStopSensor(
             "stop_name": stop_name,
             "server_time": data.server_time if data is not None else None,
             "departures": [d.to_dict() for d in departures],
-            "departures_by_line": dict(grouped),
             "next_by_line": next_by_line,
             "traffic_info": [t.to_dict() for t in traffic],
             "elevator_info": [e.to_dict() for e in elevator],

--- a/custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js
+++ b/custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js
@@ -201,10 +201,19 @@ function _collectLinesInSelection(hass, entities) {
   const seen = new Set();
   for (const stop of entities) {
     const a = hass?.states[stop.entity]?.attributes;
-    const grouped = a?.departures_by_line;
-    if (grouped && typeof grouped === "object") {
-      for (const line of Object.keys(grouped)) seen.add(line);
+    const deps = Array.isArray(a?.departures) ? a.departures : [];
+    for (const d of deps) {
+      if (d && typeof d.line === "string" && d.line) seen.add(d.line);
     }
+  }
+  return [...seen].sort();
+}
+
+function _linesAtStop(attrs) {
+  const seen = new Set();
+  const deps = Array.isArray(attrs?.departures) ? attrs.departures : [];
+  for (const d of deps) {
+    if (d && typeof d.line === "string" && d.line) seen.add(d.line);
   }
   return [...seen].sort();
 }
@@ -929,9 +938,7 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
             const a = this._hass.states[stop.entity]?.attributes;
             if (!a) return "";
             const stopName = a.stop_name || stop.entity;
-            const linesAtStop = a.departures_by_line
-              ? Object.keys(a.departures_by_line).sort()
-              : [];
+            const linesAtStop = _linesAtStop(a);
             const picked = new Set(stop.lines || []);
             const dir = stop.direction || null;
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -194,8 +194,11 @@ async def test_attributes_full_departure_list(hass: HomeAssistant) -> None:
     assert first["traffic_jam"] is False
 
 
-async def test_attributes_grouped_views(hass: HomeAssistant) -> None:
-    """`departures_by_line` groups by line, `next_by_line` picks first countdown."""
+async def test_attributes_next_by_line_and_no_grouped_duplicate(hass: HomeAssistant) -> None:
+    """next_by_line gives cheap per-line access; we deliberately do NOT publish
+    a full `departures_by_line` grouping because it duplicates every departure
+    dict under `departures` and blows past the recorder's 16 KB attribute cap
+    at busy stops."""
     entry = _make_entry()
     entry.add_to_hass(hass)
     data = MonitorData(departures=_make_departures(), server_time=None)
@@ -203,12 +206,13 @@ async def test_attributes_grouped_views(hass: HomeAssistant) -> None:
     sensor = WienerLinienStopSensor(coordinator, entry)
     attrs = sensor.extra_state_attributes
 
-    assert set(attrs["departures_by_line"].keys()) == {"U1"}
-    assert len(attrs["departures_by_line"]["U1"]) == 3
-
     # next_by_line uses the *first* occurrence per line, which is the earliest
     # countdown because the coordinator always feeds a sorted list.
     assert attrs["next_by_line"] == {"U1": 2}
+
+    # The grouped view is intentionally NOT published — consumers derive it
+    # from `departures` themselves.
+    assert "departures_by_line" not in attrs
 
 
 async def test_attributes_next_by_line_with_multiple_lines(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Problem
Recorder has been warning for every update on busy stops:
\`\`\`
WARNING (Recorder) [homeassistant.components.recorder.db_schema]
State attributes for sensor.westbahnhof_abfahrten exceed maximum size of
16384 bytes. This can cause database performance issues; Attributes will
not be stored
\`\`\`

Root cause: every departure dict was emitted twice — once as a flat list under \`departures\`, then again grouped by line under \`departures_by_line\`. Westbahnhof (~42 U6 departures × ~10 fields × 2 copies) blew past HA's 16 KB attribute cap and the recorder dropped state entirely.

## Fix
Stop publishing \`departures_by_line\`. Consumers who want a grouped view can reduce over \`departures\` themselves (the card does exactly that now).

### Files
- [sensor.py](custom_components/wiener_linien_austria/sensor.py) — drop the grouped dict from \`extra_state_attributes\`. Keep \`next_by_line\` (small per-line → int map, useful for cheap template access).
- [card JS](custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js) — \`_collectLinesInSelection\` + editor chip row both derived lines from \`departures_by_line.keys()\`. Replaced with a tiny \`_linesAtStop\` helper that iterates \`departures[]\`. No behavioural change.
- [test_sensor.py](tests/test_sensor.py) — renamed \`test_attributes_grouped_views\` to assert both \`next_by_line\` is still correct AND that \`departures_by_line\` is **not** in the attribute dict.

## Impact
- **Breaking for anyone who built a template on \`sensor.*.attributes.departures_by_line\`** — reduces to a one-liner: \`{{ state_attr('sensor.x','departures').items() | groupby('line') | list }}\`. Given the integration is hours old and no user (besides us) is configured, blast radius is zero.
- Attribute payload roughly halves. Westbahnhof now fits under the cap; recorder stores state + history properly.

## Test plan
- [x] \`python3 -m pytest tests/ -q\` — 57/57 pass
- [x] \`mypy --strict --ignore-missing-imports custom_components/wiener_linien_austria\` — clean
- [x] \`ruff check .\` — clean
- [x] Dev-pushed to rpi25 for smoke-testing the card editor (chip row still populates from \`departures\` — verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)