### PR TITLE
Release v1.1.0 — per-line walking-time filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 [![HA min version](https://img.shields.io/badge/Home%20Assistant-%3E%3D2025.1-blue.svg)](https://www.home-assistant.io/)
-[![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](https://github.com/rolandzeiner/wiener-linien-austria/releases)
+[![Version](https://img.shields.io/badge/version-1.0.1-blue.svg)](https://github.com/rolandzeiner/wiener-linien-austria/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![vibe-coded](https://img.shields.io/badge/vibe-coded-ff69b4?logo=musicbrainz&logoColor=white)](https://en.wikipedia.org/wiki/Vibe_coding)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 [![HA min version](https://img.shields.io/badge/Home%20Assistant-%3E%3D2025.1-blue.svg)](https://www.home-assistant.io/)
-[![Version](https://img.shields.io/badge/version-1.0.1-blue.svg)](https://github.com/rolandzeiner/wiener-linien-austria/releases)
+[![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)](https://github.com/rolandzeiner/wiener-linien-austria/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![vibe-coded](https://img.shields.io/badge/vibe-coded-ff69b4?logo=musicbrainz&logoColor=white)](https://en.wikipedia.org/wiki/Vibe_coding)
 
@@ -85,7 +85,7 @@ The everyday departure board. Dashboard → Add card → "Wiener Linien Austria"
 
 **Editor (visual):**
 - **Stops** — chip picker (multi-select) of every Wiener Linien sensor on this HA instance.
-- **Per-stop filters** — for each selected stop, a second chip row lets you restrict which lines render and which direction (H / R / both).
+- **Per-stop filters** — for each selected stop, a second chip row lets you restrict which lines render and which direction (H / R / both). *(1.1.0)* Under each stop's filter row, a **Walking time** input per line-direction hides departures that would already be gone by the time you reach the platform — inclusive (`countdown ≥ walk`), so you can run for the last minute. Leave blank for no filter.
 - **Line colours** — colour-pickers per line appearing in any selected stop's board. Metro CI defaults are built in; tram/bus lines fall back to the theme primary colour until overridden.
 - **Display** — multi-stop layout picker (*stacked* or *tabs*), departures-per-stop slider (1–20), and toggles for step-free icon (opt-in), disruption banner, elevator badge, delay text, and "Hide data source" (hides the attribution footer on your private dashboard — the sensor attribute keeps the CC-BY string).
 
@@ -110,7 +110,7 @@ A focused single-stop, single-direction LED-display style card mimicking the cla
 - Wheelchair glyph in amber LED tone after the destination on step-free departures.
 - Alternating asterisks blink in place of the countdown when a train is at the platform (`countdown ≤ 0`), matching the real LED boards.
 - Three size variants (small / medium / regular) for narrow mobile cards, tablet dashboards, or full-width wall displays.
-- Editor: stop chip picker, H/R direction toggle, optional single-line filter, size picker, and a show-platform toggle.
+- Editor: stop chip picker, H/R direction toggle, optional single-line filter, size picker, and a show-platform toggle. *(1.1.0)* A **Walking time** section lists every line-direction at the stop with a per-row minute input — departures leaving before you could reach the platform are hidden (inclusive: `countdown ≥ walk`).
 
 Designed for wall-tablet kiosks, entryway displays, and anyone who wants their HA dashboard to feel like an actual station board.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Type a stop name, pick it from a list, choose which lines to track. Done.
 2. Search for **Wiener Linien Austria**.
 3. Type part of a stop name (e.g. `Stephans`) and submit.
 4. Pick the matching stop from the dropdown.
-5. The integration calls the live `/monitor` endpoint and shows every line currently serving that stop. All pre-selected. Deselect any you don't care about.
+5. The integration calls the live `/monitor` endpoint and shows every line currently serving that stop. Pick the one or two you want to track — busy stops list 20+ lines.
 6. Set a polling interval (default 60 s, minimum 30 s) and save.
 
 Change tracked lines later via **Reconfigure**; change polling interval via **Configure** (options).

--- a/custom_components/wiener_linien_austria/config_flow.py
+++ b/custom_components/wiener_linien_austria/config_flow.py
@@ -303,8 +303,6 @@ class WienerLinienAustriaConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             for row in self._lines
         ]
-        all_keys = [row["key"] for row in self._lines]
-
         # Default scan interval comes from the existing entry if reconfiguring,
         # otherwise the system default.
         existing = self._reconfigure_entry
@@ -315,10 +313,14 @@ class WienerLinienAustriaConfigFlow(ConfigFlow, domain=DOMAIN):
             if existing is not None
             else DEFAULT_SCAN_INTERVAL
         )
+        # New entries start with nothing pre-selected — busy stops have
+        # 20+ lines and users typically only want one or two, so opt-in
+        # is the cheaper interaction. Reconfigure preserves whatever the
+        # user had before.
         default_lines = (
-            [str(k) for k in {**existing.data, **existing.options}.get(CONF_LINES, all_keys)]
+            [str(k) for k in {**existing.data, **existing.options}.get(CONF_LINES, [])]
             if existing is not None
-            else all_keys
+            else []
         )
 
         return self.async_show_form(

--- a/custom_components/wiener_linien_austria/const.py
+++ b/custom_components/wiener_linien_austria/const.py
@@ -8,7 +8,7 @@ from homeassistant.const import __version__ as _HA_VERSION
 DOMAIN: Final = "wiener_linien_austria"
 
 # Integration version — must match manifest.json "version" field.
-INTEGRATION_VERSION: Final = "1.0.1"
+INTEGRATION_VERSION: Final = "1.1.0"
 
 # User-Agent header sent on every outbound request. Identifying ourselves
 # beyond HA's default clientsession UA lets Wiener Linien traffic-shape or
@@ -78,9 +78,9 @@ LINE_TYPE_BUS_NIGHT: Final = "ptBusNight"
 # match the corresponding Python constant below byte-for-byte, else the
 # reload banner loops. Retro card iterates independently from the modern
 # one so the two can rev at different paces without spurious reloads.
-CARD_VERSION: Final = "1.0.1"
+CARD_VERSION: Final = "1.1.0"
 CARD_URL: Final = "/wiener-linien-austria/wiener-linien-austria-card.js"
-RETRO_CARD_VERSION: Final = "1.0.1"
+RETRO_CARD_VERSION: Final = "1.1.0"
 RETRO_CARD_URL: Final = (
     "/wiener-linien-austria/wiener-linien-austria-retro-card.js"
 )

--- a/custom_components/wiener_linien_austria/const.py
+++ b/custom_components/wiener_linien_austria/const.py
@@ -8,7 +8,7 @@ from homeassistant.const import __version__ as _HA_VERSION
 DOMAIN: Final = "wiener_linien_austria"
 
 # Integration version — must match manifest.json "version" field.
-INTEGRATION_VERSION: Final = "1.0.0"
+INTEGRATION_VERSION: Final = "1.0.1"
 
 # User-Agent header sent on every outbound request. Identifying ourselves
 # beyond HA's default clientsession UA lets Wiener Linien traffic-shape or
@@ -78,9 +78,9 @@ LINE_TYPE_BUS_NIGHT: Final = "ptBusNight"
 # match the corresponding Python constant below byte-for-byte, else the
 # reload banner loops. Retro card iterates independently from the modern
 # one so the two can rev at different paces without spurious reloads.
-CARD_VERSION: Final = "1.0.0"
+CARD_VERSION: Final = "1.0.1"
 CARD_URL: Final = "/wiener-linien-austria/wiener-linien-austria-card.js"
-RETRO_CARD_VERSION: Final = "1.0.0"
+RETRO_CARD_VERSION: Final = "1.0.1"
 RETRO_CARD_URL: Final = (
     "/wiener-linien-austria/wiener-linien-austria-retro-card.js"
 )

--- a/custom_components/wiener_linien_austria/manifest.json
+++ b/custom_components/wiener_linien_austria/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/rolandzeiner/wiener-linien-austria/issues",
   "loggers": ["custom_components.wiener_linien_austria"],
   "requirements": [],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/custom_components/wiener_linien_austria/manifest.json
+++ b/custom_components/wiener_linien_austria/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/rolandzeiner/wiener-linien-austria/issues",
   "loggers": ["custom_components.wiener_linien_austria"],
   "requirements": [],
-  "version": "1.0.1"
+  "version": "1.1.0"
 }

--- a/custom_components/wiener_linien_austria/strings.json
+++ b/custom_components/wiener_linien_austria/strings.json
@@ -20,7 +20,7 @@
       },
       "select_lines": {
         "title": "Lines at {stop_name}",
-        "description": "Found {line_count} lines currently serving this stop. Deselect any you do not want to track.",
+        "description": "Found {line_count} lines currently serving this stop. Pick the ones you want to track.",
         "data": {
           "lines": "Lines to track",
           "scan_interval": "Update interval (seconds)"

--- a/custom_components/wiener_linien_austria/translations/de.json
+++ b/custom_components/wiener_linien_austria/translations/de.json
@@ -20,7 +20,7 @@
       },
       "select_lines": {
         "title": "Linien an {stop_name}",
-        "description": "{line_count} Linien bedienen diese Haltestelle aktuell. Abwählen, was nicht verfolgt werden soll.",
+        "description": "{line_count} Linien bedienen diese Haltestelle aktuell. Wähle die Linien aus, die du verfolgen möchtest.",
         "data": {
           "lines": "Linien verfolgen",
           "scan_interval": "Aktualisierungsintervall (Sekunden)"

--- a/custom_components/wiener_linien_austria/translations/en.json
+++ b/custom_components/wiener_linien_austria/translations/en.json
@@ -20,7 +20,7 @@
       },
       "select_lines": {
         "title": "Lines at {stop_name}",
-        "description": "Found {line_count} lines currently serving this stop. Deselect any you do not want to track.",
+        "description": "Found {line_count} lines currently serving this stop. Pick the ones you want to track.",
         "data": {
           "lines": "Lines to track",
           "scan_interval": "Update interval (seconds)"

--- a/custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js
+++ b/custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js
@@ -1,10 +1,10 @@
 /**
- * Wiener Linien Austria Card v1.0.1
+ * Wiener Linien Austria Card v1.1.0
  * Custom Lovelace card for Wiener Linien departure boards.
  * https://github.com/rolandzeiner/wiener-linien-austria
  */
 
-const CARD_VERSION = "1.0.1";
+const CARD_VERSION = "1.1.0";
 
 // Metro line colours (authoritative per Wiener Linien CI). Non-metro lines
 // stay neutral until the user supplies overrides via `line_colors`.
@@ -52,6 +52,10 @@ const TRANSLATIONS = {
       filters_hint: "Linien und/oder Richtung pro Haltestelle einschränken",
       lines_label: "Linien",
       direction_label: "Richtung",
+      walk_time_label: "Fußweg (min)",
+      walk_time_hint:
+        "Abfahrten ausblenden, die bereits weg wären, bis du dort bist. Leer lassen = kein Filter.",
+      walk_time_placeholder: "–",
       section_colors: "Linienfarben",
       colors_hint:
         "Optional: Farben überschreiben. U-Bahn-Standardwerte sind gesetzt.",
@@ -106,6 +110,10 @@ const TRANSLATIONS = {
       filters_hint: "Optionally restrict lines or direction per stop",
       lines_label: "Lines",
       direction_label: "Direction",
+      walk_time_label: "Walking time (min)",
+      walk_time_hint:
+        "Hide departures that would already be gone by the time you reach the platform. Leave blank for no filter.",
+      walk_time_placeholder: "–",
       section_colors: "Line colours",
       colors_hint:
         "Optional overrides. Metro defaults are already set.",
@@ -176,6 +184,19 @@ function _normaliseStopEntry(raw) {
   if (raw.direction === "H" || raw.direction === "R") {
     out.direction = raw.direction;
   }
+  // Per-(line,direction,towards) walking-time overrides. Keys match the
+  // departure's `${line}|${direction}|${towards}` fingerprint; values are
+  // positive integer minutes. Zero / blank / non-numeric means "no filter"
+  // and is dropped so the normalised config never carries dead entries.
+  if (raw.walk_times && typeof raw.walk_times === "object" && !Array.isArray(raw.walk_times)) {
+    const clean = {};
+    for (const [k, v] of Object.entries(raw.walk_times)) {
+      if (typeof k !== "string" || !k) continue;
+      const n = parseInt(v, 10);
+      if (Number.isFinite(n) && n > 0) clean[k] = n;
+    }
+    if (Object.keys(clean).length) out.walk_times = clean;
+  }
   return out;
 }
 
@@ -239,9 +260,20 @@ function _filterDepartures(departures, stopCfg) {
   if (!Array.isArray(departures)) return [];
   const wantLines = stopCfg.lines && stopCfg.lines.length ? new Set(stopCfg.lines) : null;
   const wantDir = stopCfg.direction || null;
+  const walk = stopCfg.walk_times || null;
   return departures.filter((d) => {
     if (wantLines && !wantLines.has(d.line)) return false;
     if (wantDir && d.direction !== wantDir) return false;
+    if (walk) {
+      const key = `${d.line || ""}|${d.direction || ""}|${d.towards || ""}`;
+      const min = walk[key];
+      // Inclusive: countdown == walk ⇒ still reachable if you hurry. When the
+      // sensor hasn't reported a countdown yet we err on the side of keeping
+      // the row rather than hiding data the user might need.
+      if (Number.isFinite(min) && min > 0 && Number.isFinite(d.countdown) && d.countdown < min) {
+        return false;
+      }
+    }
     return true;
   });
 }
@@ -265,6 +297,30 @@ function _linesAtStop(attrs) {
     if (d && typeof d.line === "string" && d.line) seen.add(d.line);
   }
   return [...seen].sort();
+}
+
+function _tripletsAtStop(attrs) {
+  // Unique (line, direction, towards) triples at this stop, keyed the same
+  // way the filter / config-flow store them. Used to drive the editor's
+  // walk-time rows — one input per triple so users can set a different
+  // value for each platform direction at a station.
+  const seen = new Map();
+  const deps = Array.isArray(attrs?.departures) ? attrs.departures : [];
+  for (const d of deps) {
+    if (!d || typeof d.line !== "string" || !d.line) continue;
+    const direction = typeof d.direction === "string" ? d.direction : "";
+    const towards = typeof d.towards === "string" ? d.towards : "";
+    const key = `${d.line}|${direction}|${towards}`;
+    if (!seen.has(key)) {
+      seen.set(key, { key, line: d.line, direction, towards });
+    }
+  }
+  return [...seen.values()].sort((a, b) => {
+    if (a.line !== b.line) return a.line < b.line ? -1 : 1;
+    if (a.direction !== b.direction) return a.direction < b.direction ? -1 : 1;
+    if (a.towards === b.towards) return 0;
+    return a.towards < b.towards ? -1 : 1;
+  });
 }
 
 const CARD_STYLE = `
@@ -1522,6 +1578,47 @@ const EDITOR_STYLE = `
     color: var(--primary-text-color);
     cursor: pointer;
   }
+  .walk-time-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .walk-time-row {
+    display: grid;
+    grid-template-columns: 44px 1fr 72px;
+    align-items: center;
+    gap: 8px;
+  }
+  .walk-time-badge {
+    text-align: center;
+    font-weight: 700;
+    color: #fff;
+    border-radius: 4px;
+    padding: 2px 4px;
+    font-size: 0.9em;
+  }
+  .walk-time-towards {
+    font-size: 13px;
+    color: var(--primary-text-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .walk-time-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 4px 8px;
+    border: 1px solid var(--divider-color);
+    border-radius: 4px;
+    background: var(--card-background-color, transparent);
+    color: var(--primary-text-color);
+    font-size: 13px;
+    text-align: right;
+  }
+  .walk-time-input::-webkit-outer-spin-button,
+  .walk-time-input::-webkit-inner-spin-button {
+    margin: 0;
+  }
 `;
 
 class WienerLinienAustriaCardEditor extends HTMLElement {
@@ -1606,6 +1703,22 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
     });
   }
 
+  _setWalkTime(eid, key, rawValue) {
+    // Empty / zero / non-numeric → remove the override so the card falls
+    // back to default (show everything). Clamp positive values to 120min
+    // to keep the fingerprint stable against typos (no "1500min" entries).
+    const n = parseInt(rawValue, 10);
+    const clean = Number.isFinite(n) && n > 0 ? Math.min(120, n) : null;
+    this._updateStop(eid, (s) => {
+      const cur = { ...(s.walk_times || {}) };
+      if (clean === null) delete cur[key];
+      else cur[key] = clean;
+      if (Object.keys(cur).length) s.walk_times = cur;
+      else delete s.walk_times;
+      return s;
+    });
+  }
+
   _setLineColor(line, color) {
     const colors = { ...(this._config.line_colors || {}) };
     colors[line.toUpperCase()] = color;
@@ -1674,8 +1787,16 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
             if (!a) return "";
             const stopName = a.stop_name || stop.entity;
             const linesAtStop = _linesAtStop(a);
+            const walkTimes = stop.walk_times || {};
             const picked = new Set(stop.lines || []);
             const dir = stop.direction || null;
+            // Walk-time rows mirror the direction chip: if the user locked
+            // the card to H or R, the inverse direction's triples are
+            // irrelevant and hiding them avoids confusion. "Both" (dir=null)
+            // keeps the full list.
+            const triplets = _tripletsAtStop(a).filter(
+              (t) => !dir || t.direction === dir,
+            );
 
             const lineChips = linesAtStop.length
               ? linesAtStop
@@ -1696,6 +1817,45 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
                   .join("")
               : `<div class="editor-hint">${_esc(this._et("no_lines_available"))}</div>`;
 
+            const walkRows = triplets.length
+              ? triplets
+                  .map((t) => {
+                    const color = _colorForLine(t.line, overrides);
+                    const val = walkTimes[t.key];
+                    const arrow = t.towards ? `→ ${t.towards}` : "";
+                    return `
+                      <div class="walk-time-row">
+                        <span class="walk-time-badge" style="background:${color}">${_esc(t.line)}</span>
+                        <span class="walk-time-towards" title="${_esc(t.towards)}">${_esc(arrow)}</span>
+                        <input
+                          type="number"
+                          class="walk-time-input"
+                          min="0"
+                          max="120"
+                          step="1"
+                          inputmode="numeric"
+                          data-action="set-walk-time"
+                          data-entity="${_esc(stop.entity)}"
+                          data-key="${_esc(t.key)}"
+                          placeholder="${_esc(this._et("walk_time_placeholder"))}"
+                          value="${Number.isFinite(val) ? val : ""}"
+                        />
+                      </div>
+                    `;
+                  })
+                  .join("")
+              : "";
+
+            const walkBlock = triplets.length
+              ? `
+                <div class="stop-filter-row">
+                  <div class="stop-filter-row-label">${_esc(this._et("walk_time_label"))}</div>
+                  <div class="editor-hint">${_esc(this._et("walk_time_hint"))}</div>
+                  <div class="walk-time-list">${walkRows}</div>
+                </div>
+              `
+              : "";
+
             return `
               <div class="stop-filter">
                 <div class="stop-filter-header">${_esc(stopName)}</div>
@@ -1711,6 +1871,7 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
                     <button type="button" data-dir="" class="${dir === null ? "active" : ""}">${_esc(this._t("dir_both"))}</button>
                   </div>
                 </div>
+                ${walkBlock}
               </div>
             `;
           })
@@ -1847,6 +2008,24 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
           const dir = btn.dataset.dir;
           this._setDirection(eid, dir === "" ? null : dir);
         });
+      });
+    });
+
+    // Walk-time number inputs. Fire on `change` (blur / Enter), not `input`,
+    // so typing "10" doesn't briefly commit "1" and re-render with the
+    // wrong value under the cursor.
+    this.querySelectorAll('input[data-action="set-walk-time"]').forEach((input) => {
+      // Don't let HA's card-editor keyboard handling (e.g. Esc to close)
+      // swallow arrow keys the user wants for the number input.
+      ["keydown", "keyup", "keypress"].forEach((evt) => {
+        input.addEventListener(evt, (e) => e.stopPropagation());
+      });
+      input.addEventListener("change", (e) => {
+        this._setWalkTime(
+          e.target.dataset.entity,
+          e.target.dataset.key,
+          e.target.value,
+        );
       });
     });
 

--- a/custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js
+++ b/custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js
@@ -1,10 +1,10 @@
 /**
- * Wiener Linien Austria Card v1.0.0
+ * Wiener Linien Austria Card v1.0.1
  * Custom Lovelace card for Wiener Linien departure boards.
  * https://github.com/rolandzeiner/wiener-linien-austria
  */
 
-const CARD_VERSION = "1.0.0";
+const CARD_VERSION = "1.0.1";
 
 // Metro line colours (authoritative per Wiener Linien CI). Non-metro lines
 // stay neutral until the user supplies overrides via `line_colors`.

--- a/custom_components/wiener_linien_austria/www/wiener-linien-austria-retro-card.js
+++ b/custom_components/wiener_linien_austria/www/wiener-linien-austria-retro-card.js
@@ -1,12 +1,12 @@
 /**
- * Wiener Linien Austria Retro Card v1.0.0
+ * Wiener Linien Austria Retro Card v1.0.1
  * LED-style departure display mimicking the classic Wiener Linien platform
  * signs: amber dot-matrix text on black, with a platform panel (GLEIS for
  * rail, STEIG for bus) on the left or right depending on Gleis number.
  * https://github.com/rolandzeiner/wiener-linien-austria
  */
 
-const CARD_VERSION = "1.0.0";
+const CARD_VERSION = "1.0.1";
 
 // ------------------------------------------------------------------
 // Shared helpers. Duplicated from the modern card so the two files

--- a/custom_components/wiener_linien_austria/www/wiener-linien-austria-retro-card.js
+++ b/custom_components/wiener_linien_austria/www/wiener-linien-austria-retro-card.js
@@ -1,12 +1,12 @@
 /**
- * Wiener Linien Austria Retro Card v1.0.1
+ * Wiener Linien Austria Retro Card v1.1.0
  * LED-style departure display mimicking the classic Wiener Linien platform
  * signs: amber dot-matrix text on black, with a platform panel (GLEIS for
  * rail, STEIG for bus) on the left or right depending on Gleis number.
  * https://github.com/rolandzeiner/wiener-linien-austria
  */
 
-const CARD_VERSION = "1.0.1";
+const CARD_VERSION = "1.1.0";
 
 // ------------------------------------------------------------------
 // Shared helpers. Duplicated from the modern card so the two files
@@ -72,6 +72,12 @@ const TRANSLATIONS = {
       direction_no_data: "Keine Abfahrten in dieser Richtung",
       line_hint:
         "Optional: nur eine Linie anzeigen. Aktiven Chip erneut antippen = alle Linien.",
+      section_walk_time: "Fußweg zur Haltestelle",
+      walk_time_hint:
+        "Abfahrten ausblenden, die bereits weg wären, bis du dort bist. Leer lassen = kein Filter.",
+      walk_time_no_data:
+        "Keine Abfahrten in dieser Richtung. Richtung wechseln oder warten, bis der Sensor Linien meldet.",
+      walk_time_placeholder: "–",
       show_platform: "Gleis/Steig anzeigen",
       show_station_name: "Stationsnamen anzeigen",
       section_station: "Stationsnamen-Schild",
@@ -114,6 +120,12 @@ const TRANSLATIONS = {
       direction_no_data: "No departures in this direction",
       line_hint:
         "Optional: restrict to a single line. Tap the active chip again to show all lines.",
+      section_walk_time: "Walking time to stop",
+      walk_time_hint:
+        "Hide departures that would already be gone by the time you reach the platform. Leave blank for no filter.",
+      walk_time_no_data:
+        "No departures in this direction. Switch direction or wait until the sensor reports lines.",
+      walk_time_placeholder: "–",
       show_platform: "Show platform",
       show_station_name: "Show station name",
       section_station: "Station name sign",
@@ -173,7 +185,38 @@ function _normaliseConfig(config) {
   // Card size: regular = previous sizing, medium / small scale
   // font + padding proportionally for denser or cramped layouts.
   if (!RETRO_SIZES.has(out.size)) out.size = "regular";
+  // Walking-time overrides per `${line}|${direction}|${towards}` triple.
+  // Integer minutes > 0 only; anything else is dropped so empty inputs
+  // don't accumulate dead keys.
+  if (out.walk_times && typeof out.walk_times === "object" && !Array.isArray(out.walk_times)) {
+    const clean = {};
+    for (const [k, v] of Object.entries(out.walk_times)) {
+      if (typeof k !== "string" || !k) continue;
+      const n = parseInt(v, 10);
+      if (Number.isFinite(n) && n > 0) clean[k] = n;
+    }
+    if (Object.keys(clean).length) out.walk_times = clean;
+    else delete out.walk_times;
+  } else {
+    delete out.walk_times;
+  }
   return out;
+}
+
+function _retroWalkFilter(walk) {
+  // Returns a predicate that drops departures whose countdown is below
+  // the user-configured walking time for their triple. Inclusive: walk=5
+  // and countdown=5 ⇒ still kept (run if you need to). Missing countdown
+  // passes through — we don't penalise the user for a half-populated row.
+  if (!walk) return () => true;
+  return (d) => {
+    if (!d) return false;
+    const key = `${d.line || ""}|${d.direction || ""}|${d.towards || ""}`;
+    const min = walk[key];
+    if (!Number.isFinite(min) || min <= 0) return true;
+    if (!Number.isFinite(d.countdown)) return true;
+    return d.countdown >= min;
+  };
 }
 
 // ------------------------------------------------------------------
@@ -558,9 +601,12 @@ class WienerLinienAustriaRetroCard extends HTMLElement {
     const a = this._hass.states[eid]?.attributes || {};
     const dir = this._config.direction;
     const lineFilter = this._config.line || "";
+    const walk = this._config.walk_times || null;
+    const walkFilter = _retroWalkFilter(walk);
     const deps = (a.departures || [])
       .filter((d) => d && d.direction === dir)
       .filter((d) => !lineFilter || d.line === lineFilter)
+      .filter(walkFilter)
       .slice(0, 2)
       .map(
         (d) =>
@@ -572,7 +618,15 @@ class WienerLinienAustriaRetroCard extends HTMLElement {
     const stn = this._config.show_station_name ? "1" : "0";
     const stnBg = this._config.station_bg || "white";
     const stopName = a.stop_name || a.friendly_name || "";
-    return `${this._versionMismatch || ""}||${eid}@${a.server_time || ""}|${dir}|${lineFilter}|s${stn}|${stnBg}|${stopName}#${deps}`;
+    // Walking-time config is included so edits that hide/show a row trigger
+    // a re-render even when the raw departures themselves are unchanged.
+    const walkKey = walk
+      ? Object.keys(walk)
+          .sort()
+          .map((k) => `${k}=${walk[k]}`)
+          .join(",")
+      : "";
+    return `${this._versionMismatch || ""}||${eid}@${a.server_time || ""}|${dir}|${lineFilter}|s${stn}|${stnBg}|${stopName}|w[${walkKey}]#${deps}`;
   }
 
   _render() {
@@ -589,10 +643,12 @@ class WienerLinienAustriaRetroCard extends HTMLElement {
         attrs.departures,
       );
     }
+    const walkFilter = _retroWalkFilter(this._config.walk_times || null);
     const matching = Array.isArray(attrs.departures)
       ? attrs.departures
           .filter((d) => d && d.direction === dir)
           .filter((d) => !lineFilter || d.line === lineFilter)
+          .filter(walkFilter)
       : [];
     const rows = matching.slice(0, 2);
     const showPlatform = this._config.show_platform !== false;
@@ -864,6 +920,44 @@ const EDITOR_STYLE = `
     color: var(--primary-text-color);
     cursor: pointer;
   }
+  .walk-time-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .walk-time-row {
+    display: grid;
+    grid-template-columns: 44px 1fr 72px;
+    align-items: center;
+    gap: 8px;
+  }
+  .walk-time-badge {
+    text-align: center;
+    font-weight: 700;
+    color: #fff;
+    border-radius: 4px;
+    padding: 2px 4px;
+    font-size: 0.9em;
+    background: var(--primary-color);
+  }
+  .walk-time-towards {
+    font-size: 13px;
+    color: var(--primary-text-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .walk-time-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 4px 8px;
+    border: 1px solid var(--divider-color);
+    border-radius: 4px;
+    background: var(--card-background-color, transparent);
+    color: var(--primary-text-color);
+    font-size: 13px;
+    text-align: right;
+  }
 `;
 
 class WienerLinienAustriaRetroCardEditor extends HTMLElement {
@@ -958,6 +1052,46 @@ class WienerLinienAustriaRetroCardEditor extends HTMLElement {
     this._render();
   }
 
+  _setWalkTime(key, rawValue) {
+    // Empty / zero / non-numeric → remove the override. Clamp to 120min so
+    // a stray keypress ("500") can't push the filter far beyond the
+    // upstream's ~60-minute departure horizon.
+    const n = parseInt(rawValue, 10);
+    const clean = Number.isFinite(n) && n > 0 ? Math.min(120, n) : null;
+    const cur = { ...(this._config.walk_times || {}) };
+    if (clean === null) delete cur[key];
+    else cur[key] = clean;
+    const next = { ...this._config };
+    if (Object.keys(cur).length) next.walk_times = cur;
+    else delete next.walk_times;
+    this._config = next;
+    this._fire();
+    this._render();
+  }
+
+  _tripletsForStop() {
+    // All (line, direction, towards) triples at the currently selected stop
+    // regardless of the direction / line filter. We list both directions so
+    // the walk-time config survives toggling H↔R later.
+    const eid = this._config.entity;
+    const a = eid ? this._hass?.states[eid]?.attributes : null;
+    const deps = Array.isArray(a?.departures) ? a.departures : [];
+    const seen = new Map();
+    for (const d of deps) {
+      if (!d || typeof d.line !== "string" || !d.line) continue;
+      const direction = typeof d.direction === "string" ? d.direction : "";
+      const towards = typeof d.towards === "string" ? d.towards : "";
+      const key = `${d.line}|${direction}|${towards}`;
+      if (!seen.has(key)) seen.set(key, { key, line: d.line, direction, towards });
+    }
+    return [...seen.values()].sort((a, b) => {
+      if (a.line !== b.line) return a.line < b.line ? -1 : 1;
+      if (a.direction !== b.direction) return a.direction < b.direction ? -1 : 1;
+      if (a.towards === b.towards) return 0;
+      return a.towards < b.towards ? -1 : 1;
+    });
+  }
+
   _linesForCurrent() {
     // Lines that actually have departures for the selected
     // (entity, direction). Used to populate the line-chip picker.
@@ -1046,6 +1180,38 @@ class WienerLinienAustriaRetroCardEditor extends HTMLElement {
           .join("")
       : `<div class="editor-hint">${_esc(this._et("no_lines"))}</div>`;
 
+    const walkTimes = this._config.walk_times || {};
+    // Only show walk-time inputs for the currently-selected direction;
+    // retro is single-direction by design, so listing the inverse just
+    // creates dead inputs.
+    const triplets = selected
+      ? this._tripletsForStop().filter((t) => t.direction === direction)
+      : [];
+    const walkRows = triplets.length
+      ? triplets
+          .map((t) => {
+            const val = walkTimes[t.key];
+            return `
+              <div class="walk-time-row">
+                <span class="walk-time-badge">${_esc(t.line)}</span>
+                <span class="walk-time-towards" title="${_esc(t.towards)}">→ ${_esc(t.towards)}</span>
+                <input
+                  type="number"
+                  class="walk-time-input"
+                  min="0"
+                  max="120"
+                  step="1"
+                  inputmode="numeric"
+                  data-walk-key="${_esc(t.key)}"
+                  placeholder="${_esc(this._et("walk_time_placeholder"))}"
+                  value="${Number.isFinite(val) ? val : ""}"
+                />
+              </div>
+            `;
+          })
+          .join("")
+      : `<div class="editor-hint">${_esc(this._et("walk_time_no_data"))}</div>`;
+
     this.innerHTML = `
       <div class="editor">
         <style>${EDITOR_STYLE}</style>
@@ -1080,6 +1246,12 @@ class WienerLinienAustriaRetroCardEditor extends HTMLElement {
           <div class="section-header">${_esc(this._et("section_line"))}</div>
           <div class="editor-hint">${_esc(this._et("line_hint"))}</div>
           <div class="entity-chips">${lineChips}</div>
+        </div>
+
+        <div class="editor-section">
+          <div class="section-header">${_esc(this._et("section_walk_time"))}</div>
+          <div class="editor-hint">${_esc(this._et("walk_time_hint"))}</div>
+          <div class="walk-time-list">${walkRows}</div>
         </div>
 
         <div class="editor-section">
@@ -1159,6 +1331,17 @@ class WienerLinienAustriaRetroCardEditor extends HTMLElement {
     });
     this.querySelectorAll("button[data-size]").forEach((btn) => {
       btn.addEventListener("click", () => this._setSize(btn.dataset.size));
+    });
+    // Walk-time number inputs. Fire on `change` (blur / Enter) so typing
+    // "10" doesn't briefly commit "1" and re-render with the wrong value
+    // under the cursor.
+    this.querySelectorAll("input[data-walk-key]").forEach((input) => {
+      ["keydown", "keyup", "keypress"].forEach((evt) => {
+        input.addEventListener(evt, (e) => e.stopPropagation());
+      });
+      input.addEventListener("change", (e) => {
+        this._setWalkTime(e.target.dataset.walkKey, e.target.value);
+      });
     });
   }
 }


### PR DESCRIPTION
## Summary

- **New feature** — per `(line, direction, towards)` walking-time filter in both cards. Enter the minutes it takes you to reach a platform and the card hides departures you couldn't catch; inclusive (`countdown ≥ walk`), so you can still run for the last minute.
- **Editor UX** — walk-time rows follow the direction chip: H-only hides R triples and vice versa; retro card (single-direction) always scopes to the selected direction. Blank / zero / invalid = no filter.
- **Config-flow nit** — new line-selection forms now start empty instead of with all lines pre-checked (busy stops had 20+ defaults the user almost always wanted to deselect).
- **Version bump** — 1.0.1 → 1.1.0 across `manifest.json`, `const.py` (`INTEGRATION_VERSION`, `CARD_VERSION`, `RETRO_CARD_VERSION`), both card JS files, and the README badge.

## Test plan

- [x] `python3 -m pytest tests/ -v` — 78 pass
- [x] `ruff check .` — clean
- [x] `mypy --strict --ignore-missing-imports custom_components/wiener_linien_austria` — clean
- [x] Dev-pushed + verified on live HA: sensor loads with departures, attribution intact, no errors in log.
- [ ] Reviewer: open a card editor, set a walking time on a line, confirm rows with `countdown < walk` disappear; clear the field and confirm they return.