### PR TITLE
Release v1.1.1 — Shadow DOM CSS isolation + retro polish

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+# Scans Python (integration) + JavaScript/TypeScript (Lovelace cards).
+# Runs on every push to main/dev, every PR targeting main, and once a
+# week on Tuesday at 04:23 UTC to catch newly-published advisories
+# against code that hasn't been touched since the last scan.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 4 * * 2"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+      packages: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 [![HA min version](https://img.shields.io/badge/Home%20Assistant-%3E%3D2025.1-blue.svg)](https://www.home-assistant.io/)
-[![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)](https://github.com/rolandzeiner/wiener-linien-austria/releases)
+[![Version](https://img.shields.io/badge/version-1.1.1-blue.svg)](https://github.com/rolandzeiner/wiener-linien-austria/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![vibe-coded](https://img.shields.io/badge/vibe-coded-ff69b4?logo=musicbrainz&logoColor=white)](https://en.wikipedia.org/wiki/Vibe_coding)
 

--- a/custom_components/wiener_linien_austria/const.py
+++ b/custom_components/wiener_linien_austria/const.py
@@ -78,9 +78,9 @@ LINE_TYPE_BUS_NIGHT: Final = "ptBusNight"
 # match the corresponding Python constant below byte-for-byte, else the
 # reload banner loops. Retro card iterates independently from the modern
 # one so the two can rev at different paces without spurious reloads.
-CARD_VERSION: Final = "1.1.0"
+CARD_VERSION: Final = "1.1.1"
 CARD_URL: Final = "/wiener-linien-austria/wiener-linien-austria-card.js"
-RETRO_CARD_VERSION: Final = "1.1.0"
+RETRO_CARD_VERSION: Final = "1.1.1"
 RETRO_CARD_URL: Final = (
     "/wiener-linien-austria/wiener-linien-austria-retro-card.js"
 )

--- a/custom_components/wiener_linien_austria/manifest.json
+++ b/custom_components/wiener_linien_austria/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/rolandzeiner/wiener-linien-austria/issues",
   "loggers": ["custom_components.wiener_linien_austria"],
   "requirements": [],
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js
+++ b/custom_components/wiener_linien_austria/www/wiener-linien-austria-card.js
@@ -1,10 +1,10 @@
 /**
- * Wiener Linien Austria Card v1.1.0
+ * Wiener Linien Austria Card v1.1.1
  * Custom Lovelace card for Wiener Linien departure boards.
  * https://github.com/rolandzeiner/wiener-linien-austria
  */
 
-const CARD_VERSION = "1.1.0";
+const CARD_VERSION = "1.1.1";
 
 // Metro line colours (authoritative per Wiener Linien CI). Non-metro lines
 // stay neutral until the user supplies overrides via `line_colors`.
@@ -706,6 +706,15 @@ class WienerLinienAustriaCard extends HTMLElement {
   _expandedTraffic = new Set();
   _expandedElevator = new Set();
 
+  constructor() {
+    super();
+    // Shadow DOM scopes our CSS — without it, every class name (.wl-row,
+    // .wl-stop, .stop-name, .chip, .tab, .editor, …) leaks into the global
+    // page scope and collides with sibling custom cards rendered into
+    // light DOM.
+    this.attachShadow({ mode: "open" });
+  }
+
   setConfig(config) {
     if (config === null || typeof config !== "object" || Array.isArray(config)) {
       throw new Error("wiener-linien-austria-card: config must be an object");
@@ -869,7 +878,7 @@ class WienerLinienAustriaCard extends HTMLElement {
       ? ""
       : `<div class="wl-attr">${_esc(attribution)}</div>`;
 
-    this.innerHTML = `
+    this.shadowRoot.innerHTML =`
       <ha-card>
         <style>${CARD_STYLE}</style>
         <div class="wl-card">
@@ -882,7 +891,7 @@ class WienerLinienAustriaCard extends HTMLElement {
       </ha-card>
     `;
 
-    const reloadBtn = this.querySelector(".wl-banner button");
+    const reloadBtn = this.shadowRoot.querySelector(".wl-banner button");
     if (reloadBtn) {
       reloadBtn.addEventListener("click", () => this._reload());
     }
@@ -890,7 +899,7 @@ class WienerLinienAustriaCard extends HTMLElement {
     // Tab-bar click handler: switch active stop and re-render. We call
     // `_render()` directly rather than flip the fingerprint so the flicker
     // short-circuit stays intact for coordinator polls.
-    this.querySelectorAll(".wl-tab[data-tab]").forEach((btn) => {
+    this.shadowRoot.querySelectorAll(".wl-tab[data-tab]").forEach((btn) => {
       btn.addEventListener("click", () => {
         const i = parseInt(btn.dataset.tab, 10);
         if (Number.isFinite(i) && i !== this._activeTab) {
@@ -900,7 +909,7 @@ class WienerLinienAustriaCard extends HTMLElement {
       });
     });
 
-    this.querySelectorAll("[data-dev-action]").forEach((btn) => {
+    this.shadowRoot.querySelectorAll("[data-dev-action]").forEach((btn) => {
       btn.addEventListener("click", () => {
         const action = btn.dataset.devAction;
         if (action === "traffic") this._devTestTraffic();
@@ -910,7 +919,7 @@ class WienerLinienAustriaCard extends HTMLElement {
     });
 
     // Toggle traffic-item expand/collapse.
-    this.querySelectorAll("[data-traffic-name]").forEach((el) => {
+    this.shadowRoot.querySelectorAll("[data-traffic-name]").forEach((el) => {
       // Skip items that have no detail to reveal.
       if (!el.querySelector(".wl-traffic-detail")) return;
       el.addEventListener("click", () => {
@@ -926,7 +935,7 @@ class WienerLinienAustriaCard extends HTMLElement {
     });
 
     // Toggle elevator-detail expand/collapse.
-    this.querySelectorAll("[data-elevator-name]").forEach((el) => {
+    this.shadowRoot.querySelectorAll("[data-elevator-name]").forEach((el) => {
       if (!el.querySelector(".wl-elevator-detail-expand")) return;
       el.addEventListener("click", () => {
         const name = el.dataset.elevatorName;
@@ -1625,6 +1634,11 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
   _config = {};
   _hass = null;
 
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+  }
+
   setConfig(config) {
     if (config === null || typeof config !== "object" || Array.isArray(config)) {
       throw new Error("wiener-linien-austria-card: config must be an object");
@@ -1657,9 +1671,13 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
   }
 
   _fireChanged() {
+    // bubbles + composed required so the event crosses our shadow boundary
+    // and reaches the dashboard's card editor listener.
     this.dispatchEvent(
       new CustomEvent("config-changed", {
         detail: { config: { ...this._config } },
+        bubbles: true,
+        composed: true,
       }),
     );
   }
@@ -1897,7 +1915,7 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
           .join("")
       : `<div class="editor-hint">${_esc(this._et("no_lines_available"))}</div>`;
 
-    this.innerHTML = `
+    this.shadowRoot.innerHTML =`
       <div class="editor">
         <style>${EDITOR_STYLE}</style>
 
@@ -1989,19 +2007,19 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
 
   _attachListeners() {
     // Stop toggle
-    this.querySelectorAll('[data-action="toggle-stop"]').forEach((chip) => {
+    this.shadowRoot.querySelectorAll('[data-action="toggle-stop"]').forEach((chip) => {
       chip.addEventListener("click", () => this._toggleStop(chip.dataset.entity));
     });
 
     // Line filter toggle
-    this.querySelectorAll('[data-action="toggle-line"]').forEach((chip) => {
+    this.shadowRoot.querySelectorAll('[data-action="toggle-line"]').forEach((chip) => {
       chip.addEventListener("click", () =>
         this._toggleLine(chip.dataset.entity, chip.dataset.line),
       );
     });
 
     // Direction buttons
-    this.querySelectorAll(".direction-buttons").forEach((grp) => {
+    this.shadowRoot.querySelectorAll(".direction-buttons").forEach((grp) => {
       const eid = grp.dataset.entity;
       grp.querySelectorAll("button").forEach((btn) => {
         btn.addEventListener("click", () => {
@@ -2014,7 +2032,7 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
     // Walk-time number inputs. Fire on `change` (blur / Enter), not `input`,
     // so typing "10" doesn't briefly commit "1" and re-render with the
     // wrong value under the cursor.
-    this.querySelectorAll('input[data-action="set-walk-time"]').forEach((input) => {
+    this.shadowRoot.querySelectorAll('input[data-action="set-walk-time"]').forEach((input) => {
       // Don't let HA's card-editor keyboard handling (e.g. Esc to close)
       // swallow arrow keys the user wants for the number input.
       ["keydown", "keyup", "keypress"].forEach((evt) => {
@@ -2030,12 +2048,12 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
     });
 
     // Colour pickers
-    this.querySelectorAll('input[type="color"][data-line]').forEach((input) => {
+    this.shadowRoot.querySelectorAll('input[type="color"][data-line]').forEach((input) => {
       input.addEventListener("change", (e) => {
         this._setLineColor(input.dataset.line, e.target.value);
       });
     });
-    this.querySelectorAll("[data-reset-line]").forEach((btn) => {
+    this.shadowRoot.querySelectorAll("[data-reset-line]").forEach((btn) => {
       btn.addEventListener("click", () => {
         if (btn.disabled) return;
         this._resetLineColor(btn.dataset.resetLine);
@@ -2043,7 +2061,7 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
     });
 
     // Max-departures slider
-    this.querySelectorAll('input[type="range"]').forEach((input) => {
+    this.shadowRoot.querySelectorAll('input[type="range"]').forEach((input) => {
       ["keydown", "keyup", "keypress"].forEach((evt) => {
         input.addEventListener(evt, (e) => e.stopPropagation());
       });
@@ -2061,7 +2079,7 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
     });
 
     // Display-section switches (accessibility / traffic / elevator)
-    this.querySelectorAll("ha-switch[data-field]").forEach((sw) => {
+    this.shadowRoot.querySelectorAll("ha-switch[data-field]").forEach((sw) => {
       sw.addEventListener("change", (e) => {
         const field = e.target.dataset.field;
         this._config = { ...this._config, [field]: e.target.checked };
@@ -2071,7 +2089,7 @@ class WienerLinienAustriaCardEditor extends HTMLElement {
     });
 
     // Layout buttons (stacked / tabs)
-    this.querySelectorAll("button[data-layout]").forEach((btn) => {
+    this.shadowRoot.querySelectorAll("button[data-layout]").forEach((btn) => {
       btn.addEventListener("click", () => this._setLayout(btn.dataset.layout));
     });
   }

--- a/custom_components/wiener_linien_austria/www/wiener-linien-austria-retro-card.js
+++ b/custom_components/wiener_linien_austria/www/wiener-linien-austria-retro-card.js
@@ -244,12 +244,14 @@ const RETRO_STYLE = `
       circle, var(--led-substrate) 0.5px, transparent 1px
     );
     background-size: 4px 4px;
-    padding: 14px 14px;
-    /* Slightly roomier gutter on the left so line badges (U6, N25…)
-       don't sit flush against the card edge. Right side is snugged in
-       a further 4px compared to the base so the countdown sits closer
-       to the card edge. */
-    padding-left: 22px;
+    /* 22px gutter on edges without the Gleis/Steig panel, 14px on the
+       edge that has it. The panel has its own separator (border +
+       margin), so extra card-edge air there would read as a gap rather
+       than breathing room. Specific sides are trimmed by the
+       .retro--gleis-{left,right} modifiers below; when the panel is
+       hidden, both sides keep the 22px air so the line badge and
+       countdown both get room. */
+    padding: 14px 22px;
     /* Pure system monospace stack — avoids a Google-Fonts CDN fetch
        (GDPR) and the @import-inside-Lovelace flakiness. Bold + wider
        letter-spacing gives the retro fixed-pitch LED feel without a
@@ -268,6 +270,12 @@ const RETRO_STYLE = `
   }
   /* Gleis "2" sits on the left per the station displays. */
   .retro--gleis-left .retro-gleis { order: -1; }
+  /* Trim the card-edge gutter on the side that carries the Gleis/Steig
+     panel — that side has its own separator, so the card-edge air
+     would read as a gap. .retro--no-gleis skips the trim entirely
+     (symmetric 22px on both sides). */
+  .retro--gleis-right { padding-right: 14px; }
+  .retro--gleis-left { padding-left: 14px; }
   .retro-rows {
     flex: 1;
     display: flex;
@@ -387,10 +395,11 @@ const RETRO_STYLE = `
   /* ---- size variants ---- */
   /* "regular" uses the base sizing above — no override needed. */
   .retro--size-medium {
-    padding: 11px 10px;
-    padding-left: 18px;
+    padding: 11px 18px;
     min-height: 92px;
   }
+  .retro--size-medium.retro--gleis-right { padding-right: 10px; }
+  .retro--size-medium.retro--gleis-left { padding-left: 10px; }
   .retro--size-medium .retro-rows { font-size: 1.55em; gap: 6px; }
   .retro--size-medium .retro-gleis { padding: 0 10px 0 14px; min-width: 48px; }
   .retro--size-medium.retro--gleis-left .retro-gleis {
@@ -403,10 +412,11 @@ const RETRO_STYLE = `
   }
 
   .retro--size-small {
-    padding: 8px 6px;
-    padding-left: 14px;
+    padding: 8px 14px;
     min-height: 72px;
   }
+  .retro--size-small.retro--gleis-right { padding-right: 6px; }
+  .retro--size-small.retro--gleis-left { padding-left: 6px; }
   .retro--size-small .retro-rows { font-size: 1.25em; gap: 4px; }
   .retro--size-small .retro-row {
     grid-template-columns: 2em 1fr auto;
@@ -448,11 +458,11 @@ const RETRO_STYLE = `
     align-items: center;
     justify-content: center;
     text-align: center;
-    margin: -14px -14px 10px;
-    /* Match the asymmetric padding on .retro so the panel still bleeds
-       to the card edge on both sides. */
-    margin-left: -22px;
-    padding: 16px 16px;
+    /* Mirrors the .retro padding so the panel still bleeds exactly to
+       the card edges on both sides. The gleis-side modifiers below
+       nudge the trimmed side back to -14px to match. */
+    margin: -14px -22px 10px;
+    padding: 11px 16px;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
                  Helvetica, Arial, sans-serif;
     font-weight: 700;
@@ -465,19 +475,25 @@ const RETRO_STYLE = `
   .retro-station-name {
     text-shadow: none;
   }
-  /* Size variants scale the station panel alongside the LED display */
+  /* Size variants scale the station panel alongside the LED display.
+     Base margins mirror the symmetric-air padding; gleis-side modifiers
+     trim the matching edge back. */
   .retro--size-medium .retro-station {
-    margin: -11px -10px 8px;
-    margin-left: -18px;
-    padding: 13px 14px;
+    margin: -11px -18px 8px;
+    padding: 9px 14px;
     font-size: 1.65em;
   }
   .retro--size-small .retro-station {
-    margin: -8px -6px 6px;
-    margin-left: -14px;
-    padding: 10px 10px;
+    margin: -8px -14px 6px;
+    padding: 7px 10px;
     font-size: 1.35em;
   }
+  .retro--gleis-right .retro-station { margin-right: -14px; }
+  .retro--gleis-left .retro-station { margin-left: -14px; }
+  .retro--size-medium.retro--gleis-right .retro-station { margin-right: -10px; }
+  .retro--size-medium.retro--gleis-left .retro-station { margin-left: -10px; }
+  .retro--size-small.retro--gleis-right .retro-station { margin-right: -6px; }
+  .retro--size-small.retro--gleis-left .retro-station { margin-left: -6px; }
   .retro-banner {
     background: #ffa000;
     color: #000;
@@ -713,7 +729,11 @@ class WienerLinienAustriaRetroCard extends HTMLElement {
 
     const retroClass = [
       "retro",
-      gleisLeft ? "retro--gleis-left" : "",
+      platform
+        ? gleisLeft
+          ? "retro--gleis-left"
+          : "retro--gleis-right"
+        : "retro--no-gleis",
       size !== "regular" ? `retro--size-${size}` : "",
     ]
       .filter(Boolean)
@@ -1265,6 +1285,7 @@ class WienerLinienAustriaRetroCardEditor extends HTMLElement {
               ${showStationName ? "checked" : ""}
             ></ha-switch>
           </div>
+          ${showStationName ? `
           <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-top:4px;flex-wrap:wrap;">
             <span style="font-size:13px;">${_esc(this._et("station_bg_label"))}</span>
             <div class="direction-buttons">
@@ -1273,6 +1294,7 @@ class WienerLinienAustriaRetroCardEditor extends HTMLElement {
               <button type="button" data-station-bg="black" class="${stationBg === "black" ? "active" : ""}">${_esc(this._et("station_bg_black"))}</button>
             </div>
           </div>
+          ` : ""}
         </div>
 
         <div class="editor-section">

--- a/custom_components/wiener_linien_austria/www/wiener-linien-austria-retro-card.js
+++ b/custom_components/wiener_linien_austria/www/wiener-linien-austria-retro-card.js
@@ -1,12 +1,12 @@
 /**
- * Wiener Linien Austria Retro Card v1.1.0
+ * Wiener Linien Austria Retro Card v1.1.1
  * LED-style departure display mimicking the classic Wiener Linien platform
  * signs: amber dot-matrix text on black, with a platform panel (GLEIS for
  * rail, STEIG for bus) on the left or right depending on Gleis number.
  * https://github.com/rolandzeiner/wiener-linien-austria
  */
 
-const CARD_VERSION = "1.1.0";
+const CARD_VERSION = "1.1.1";
 
 // ------------------------------------------------------------------
 // Shared helpers. Duplicated from the modern card so the two files
@@ -530,6 +530,14 @@ class WienerLinienAustriaRetroCard extends HTMLElement {
   _versionMismatch = null;
   _lastFingerprint = null;
 
+  constructor() {
+    super();
+    // Shadow DOM scopes our CSS — without it, every class name (.retro-row,
+    // .retro-line, .retro-station, .chip, …) leaks into the global page
+    // scope and collides with sibling custom cards rendered into light DOM.
+    this.attachShadow({ mode: "open" });
+  }
+
   setConfig(config) {
     if (config === null || typeof config !== "object" || Array.isArray(config)) {
       throw new Error("wiener-linien-austria-retro-card: config must be an object");
@@ -738,7 +746,7 @@ class WienerLinienAustriaRetroCard extends HTMLElement {
     ]
       .filter(Boolean)
       .join(" ");
-    this.innerHTML = `
+    this.shadowRoot.innerHTML =`
       <ha-card style="background:${LED_BG};padding:0;overflow:hidden;">
         <style>${RETRO_STYLE}</style>
         <div class="${retroClass}">
@@ -749,7 +757,7 @@ class WienerLinienAustriaRetroCard extends HTMLElement {
       </ha-card>
     `;
 
-    const reloadBtn = this.querySelector(".retro-banner button");
+    const reloadBtn = this.shadowRoot.querySelector(".retro-banner button");
     if (reloadBtn) reloadBtn.addEventListener("click", () => this._reload());
   }
 
@@ -984,6 +992,11 @@ class WienerLinienAustriaRetroCardEditor extends HTMLElement {
   _config = {};
   _hass = null;
 
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+  }
+
   setConfig(config) {
     if (config === null || typeof config !== "object" || Array.isArray(config)) {
       throw new Error("wiener-linien-austria-retro-card: config must be an object");
@@ -1016,9 +1029,13 @@ class WienerLinienAustriaRetroCardEditor extends HTMLElement {
   }
 
   _fire() {
+    // bubbles + composed required so the event crosses our shadow boundary
+    // and reaches the dashboard's card editor listener.
     this.dispatchEvent(
       new CustomEvent("config-changed", {
         detail: { config: { ...this._config } },
+        bubbles: true,
+        composed: true,
       }),
     );
   }
@@ -1232,7 +1249,7 @@ class WienerLinienAustriaRetroCardEditor extends HTMLElement {
           .join("")
       : `<div class="editor-hint">${_esc(this._et("walk_time_no_data"))}</div>`;
 
-    this.innerHTML = `
+    this.shadowRoot.innerHTML =`
       <div class="editor">
         <style>${EDITOR_STYLE}</style>
 
@@ -1319,45 +1336,45 @@ class WienerLinienAustriaRetroCardEditor extends HTMLElement {
       </div>
     `;
 
-    this.querySelectorAll(".chip[data-entity]").forEach((chip) => {
+    this.shadowRoot.querySelectorAll(".chip[data-entity]").forEach((chip) => {
       chip.addEventListener("click", () =>
         this._pickEntity(chip.dataset.entity),
       );
     });
-    this.querySelectorAll(".direction-buttons button").forEach((btn) => {
+    this.shadowRoot.querySelectorAll(".direction-buttons button").forEach((btn) => {
       btn.addEventListener("click", () => this._setDirection(btn.dataset.dir));
     });
-    this.querySelectorAll(".chip[data-line]").forEach((chip) => {
+    this.shadowRoot.querySelectorAll(".chip[data-line]").forEach((chip) => {
       chip.addEventListener("click", () =>
         this._pickLine(chip.dataset.line),
       );
     });
-    this.querySelectorAll("ha-switch[data-field='show_platform']").forEach(
+    this.shadowRoot.querySelectorAll("ha-switch[data-field='show_platform']").forEach(
       (sw) => {
         sw.addEventListener("change", (e) =>
           this._setShowPlatform(e.target.checked),
         );
       },
     );
-    this.querySelectorAll("ha-switch[data-field='show_station_name']").forEach(
+    this.shadowRoot.querySelectorAll("ha-switch[data-field='show_station_name']").forEach(
       (sw) => {
         sw.addEventListener("change", (e) =>
           this._setShowStationName(e.target.checked),
         );
       },
     );
-    this.querySelectorAll("button[data-station-bg]").forEach((btn) => {
+    this.shadowRoot.querySelectorAll("button[data-station-bg]").forEach((btn) => {
       btn.addEventListener("click", () =>
         this._setStationBg(btn.dataset.stationBg),
       );
     });
-    this.querySelectorAll("button[data-size]").forEach((btn) => {
+    this.shadowRoot.querySelectorAll("button[data-size]").forEach((btn) => {
       btn.addEventListener("click", () => this._setSize(btn.dataset.size));
     });
     // Walk-time number inputs. Fire on `change` (blur / Enter) so typing
     // "10" doesn't briefly commit "1" and re-render with the wrong value
     // under the cursor.
-    this.querySelectorAll("input[data-walk-key]").forEach((input) => {
+    this.shadowRoot.querySelectorAll("input[data-walk-key]").forEach((input) => {
       ["keydown", "keyup", "keypress"].forEach((evt) => {
         input.addEventListener(evt, (e) => e.stopPropagation());
       });

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
 pytest-homeassistant-custom-component
-pytest-asyncio
 mypy
+ruff


### PR DESCRIPTION
## Summary

- **CSS isolation via Shadow DOM** (both cards) — `WienerLinienAustriaCard` + editor, and `WienerLinienAustriaRetroCard` + editor, all attach an open shadow root in their constructor. Internal class names (`.wl-row`, `.wl-stop`, `.stop-name`, `.chip`, `.tab`, `.editor`, `.retro-row`, `.retro-line`, …) stop leaking into the global page scope. Fixes visual collisions when our cards sit on the same dashboard as another HACS card with overlapping selectors. Also fixed a latent `config-changed` event-flag bug in both editors that the shadow boundary exposed (events now have `bubbles: true, composed: true`).
- **Retro card polish** — gleis-aware gutter, trimmed station-panel padding.
- **CI** — CodeQL analysis added (Python + JS/TS, weekly + push/PR).
- **Test deps** — drop redundant `pytest-asyncio`, add `ruff`.

Bumped to `1.1.1` across `manifest.json`, `const.py` (`CARD_VERSION` + `RETRO_CARD_VERSION`), both card JS files, and the README badge.

## Test plan

- [x] HACS validation + hassfest pass on the release commit (CI)
- [x] CodeQL workflow runs clean
- [x] `pytest tests/ -v` — all 78 tests green
- [x] `mypy --strict --ignore-missing-imports custom_components/wiener_linien_austria` — clean
- [x] `ruff check .` — clean
- [x] Both cards render normally on a real dashboard: stop list, line/direction chips, departure countdown, traffic + elevator banners
- [x] Visual editor opens, all controls render, config-changed events save (verifies Shadow DOM did not break the editor → dashboard event flow)
- [x] Two WL cards (or WL + tankstellen + nextbike) on the same dashboard render independently (Shadow DOM isolation)