### PR TITLE
refactor: Platinum compliance sweep (typed ConfigEntry alias, explicit config_entry kwarg, UA regression test)

### DIFF
--- a/custom_components/wiener_linien_austria/__init__.py
+++ b/custom_components/wiener_linien_austria/__init__.py
@@ -10,7 +10,6 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.components.websocket_api import ActiveConnection  # type: ignore[attr-defined]
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import CoreState, Event, HomeAssistant
 from homeassistant.helpers import config_validation as cv
@@ -28,7 +27,7 @@ from .const import (
     RETRO_CARD_VERSION,
     STATIC_CACHE_REFRESH_HOURS,
 )
-from .coordinator import WienerLinienAustriaCoordinator
+from .coordinator import WienerLinienAustriaCoordinator, WienerLinienConfigEntry
 from .static import async_refresh_catalogue
 
 # Registered Lovelace cards shipped with this integration. Each tuple is
@@ -211,7 +210,7 @@ async def _async_register_one_card(
         )
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: WienerLinienConfigEntry) -> bool:
     """Set up Wiener Linien Austria from a config entry."""
     coordinator = WienerLinienAustriaCoordinator(hass, entry)
     await coordinator.async_setup()
@@ -236,17 +235,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _async_reload_entry(hass: HomeAssistant, entry: WienerLinienConfigEntry) -> None:
     """Reload the config entry when options are updated."""
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: WienerLinienConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_migrate_entry(hass: HomeAssistant, entry: WienerLinienConfigEntry) -> bool:
     """Placeholder for future schema migrations.
 
     v0.1.0 ships with `entry.version = 1`. When we change the schema we bump

--- a/custom_components/wiener_linien_austria/coordinator.py
+++ b/custom_components/wiener_linien_austria/coordinator.py
@@ -98,6 +98,7 @@ class WienerLinienAustriaCoordinator(DataUpdateCoordinator[MonitorData]):
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=entry,
             name=DOMAIN,
             update_interval=timedelta(seconds=scan),
         )

--- a/custom_components/wiener_linien_austria/coordinator.py
+++ b/custom_components/wiener_linien_austria/coordinator.py
@@ -376,3 +376,10 @@ def _safe_int(value: Any) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+# Threaded through every signature that reads `entry.runtime_data` — required
+# by Platinum `runtime-data` + `strict-typing`. Signatures that only use the
+# entry for construction (coordinator __init__) or for IDs/title (sensor
+# __init__, options-flow staticmethod) keep plain `ConfigEntry`.
+type WienerLinienConfigEntry = ConfigEntry[WienerLinienAustriaCoordinator]

--- a/custom_components/wiener_linien_austria/diagnostics.py
+++ b/custom_components/wiener_linien_austria/diagnostics.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .alerts import get_alerts_for
 from .const import ATTRIBUTION, CONF_LINES, CONF_RBLS
-from .coordinator import WienerLinienAustriaCoordinator
+from .coordinator import WienerLinienConfigEntry
 
 # No credentials to redact (Wiener Linien OGD has no API key), and RBL/DIVA
 # values are public station identifiers, not PII. Keep the set defensive in
@@ -18,10 +17,10 @@ TO_REDACT: set[str] = set()
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: WienerLinienConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: WienerLinienAustriaCoordinator = entry.runtime_data
+    coordinator = entry.runtime_data
     data = coordinator.data
 
     config = {**entry.data, **entry.options}

--- a/custom_components/wiener_linien_austria/sensor.py
+++ b/custom_components/wiener_linien_austria/sensor.py
@@ -22,7 +22,12 @@ from .const import (
     DOMAIN,
     MAX_DEPARTURES_IN_ATTRS,
 )
-from .coordinator import Departure, MonitorData, WienerLinienAustriaCoordinator
+from .coordinator import (
+    Departure,
+    MonitorData,
+    WienerLinienAustriaCoordinator,
+    WienerLinienConfigEntry,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,11 +36,11 @@ PARALLEL_UPDATES = 0
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: WienerLinienConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the single stop sensor for this entry."""
-    coordinator: WienerLinienAustriaCoordinator = entry.runtime_data
+    coordinator = entry.runtime_data
     async_add_entities([WienerLinienStopSensor(coordinator, entry)])
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,7 +1,7 @@
 """Tests for the Wiener Linien Austria config flow."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 from homeassistant import config_entries
@@ -16,6 +16,7 @@ from custom_components.wiener_linien_austria.const import (
     CONF_SEARCH_QUERY,
     CONF_STOP_NAME,
     DOMAIN,
+    USER_AGENT,
 )
 
 DEFAULT_LINES = ["U1|H|Leopoldau", "U1|R|Alaudagasse"]
@@ -282,3 +283,37 @@ async def test_reconfigure_aborts_when_stop_removed_from_catalogue(
         )
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "stop_gone"
+
+
+async def test_probe_sends_canonical_user_agent(hass: HomeAssistant) -> None:
+    """Config-flow's /monitor trial probe sends the canonical USER_AGENT.
+
+    Regression guard paired with the coordinator-side check in
+    test_coordinator.py::test_fetch_sends_user_agent_header. Malformed UA
+    is silent — nothing on the client side breaks — but Wiener Linien's
+    log parsers rely on the RFC-9110 slash-separated format to attribute
+    and contact this integration specifically. Bypass the `mock_fetch`
+    fixture (which stubs `_probe_monitor_lines` wholesale) and patch at
+    the session layer so the real code path runs.
+    """
+    from custom_components.wiener_linien_austria.config_flow import (
+        _probe_monitor_lines,
+    )
+
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = AsyncMock(
+        return_value={"message": {"messageCode": 1}, "data": {"monitors": []}}
+    )
+    session = MagicMock()
+    session.get = AsyncMock(return_value=resp)
+
+    with patch(
+        "custom_components.wiener_linien_austria.config_flow.async_get_clientsession",
+        return_value=session,
+    ):
+        await _probe_monitor_lines(hass, [4111, 4118])
+
+    assert session.get.await_count == 1
+    headers = session.get.call_args.kwargs["headers"]
+    assert headers == {"User-Agent": USER_AGENT}


### PR DESCRIPTION
## Summary

Three orthogonal Platinum-compliance fixes, one commit each (~60 LOC total).

- **`refactor: thread WienerLinienConfigEntry typed alias through runtime-data signatures`** — adds `type WienerLinienConfigEntry = ConfigEntry[WienerLinienAustriaCoordinator]` in `coordinator.py` and threads it through `__init__.py` (`async_setup_entry`/`async_unload_entry`/`async_migrate_entry`/`_async_reload_entry`), `sensor.py::async_setup_entry`, and `diagnostics.py`. Construction-time and ID-only signatures (Coordinator `__init__`, `WienerLinienStopSensor.__init__`, options-flow staticmethod) keep plain `ConfigEntry` — required by the Platinum `runtime-data` + `strict-typing` rules.
- **`fix: pass explicit config_entry=entry to DataUpdateCoordinator`** — HA 2025.11 deprecated the implicit ContextVar fallback; 2026.8 removes it. One-line change in the coordinator's `super().__init__()`.
- **`test: regression-guard config-flow USER-Agent header`** — the coordinator call site already had a test; the config-flow `_probe_monitor_lines` call site did not (existing `mock_fetch` fixture stubs it wholesale). New test patches `async_get_clientsession` so the real code path runs and asserts on the outbound `headers` kwarg. Canonical `USER_AGENT` in `const.py` was already in place and used at all four call sites — only the regression test was missing.

## Test plan

- [x] `ruff check .` clean
- [x] `mypy --strict --ignore-missing-imports custom_components/wiener_linien_austria` clean (8 source files)
- [x] `pytest tests/ -q` — 79 passed (+1 from the new regression test)
- [ ] CI: validate-hacs, validate-hassfest, tests all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)