### PR TITLE
chore: un-track scripts/ and gitignore local dev tooling (#14)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ secrets.yaml
 *.log
 pip-log.txt
 pip-delete-this-directory.txt
+
+# Local dev tooling — dev-push scripts are personal, not shared repo code
+scripts/
+dev-push.sh


### PR DESCRIPTION
Mirrors the matching commit on dev (5d55633). scripts/ is personal dev tooling per the ha-integration-platinum skill — shouldn't have been tracked on main either. Removing from git (git rm --cached keeps the local file on disk) and gitignoring scripts/ + dev-push.sh so a bulk 'git add .' can't re-track it.