### PR TITLE
chore(deps): retarget Dependabot PRs to dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -11,12 +12,14 @@ updates:
 
   - package-ecosystem: pip
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
 
   - package-ecosystem: npm
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Adds `target-branch: dev` to all three ecosystems (github-actions, pip, npm) in `.github/dependabot.yml`
- Dependabot reads its config from the default branch (`main`), so without this setting every dependency PR lands directly against `main`, bypassing the dev → main release flow used by the rest of the portfolio
- Same change already on `dev` (commit `6b9cb5f`); this surgical PR aligns `main` without a version bump or release
- Once merged, the two currently-open Dependabot PRs (#38, #39) targeting `main` will be retargeted by hand and rebased; future bumps will queue against `dev` automatically

## Test plan

- [ ] Confirm `.github/dependabot.yml` on `main` matches the version on `dev`
- [ ] After merge, watch the next Dependabot run and verify the next PR opens against `dev`
- [ ] No tag, no release — this is config-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)