### PR TITLE
chore: Dependabot monthly cadence + grouped dev-deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /
     target-branch: dev
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 5
     groups:
       actions:
@@ -14,15 +14,23 @@ updates:
     directory: /
     target-branch: dev
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 5
+    groups:
+      python-dev:
+        patterns: ["*"]
 
   - package-ecosystem: npm
     directory: /
     target-branch: dev
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 5
     groups:
       card-deps:
         patterns: ["*"]
+    ignore:
+      # TypeScript 7 (tsgo/native compiler) — hold until the strict-mode
+      # toolchain is deliberately migrated. Revisit; don't auto-bump.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Reduces Dependabot PR volume with identical security coverage. Config-only — no runtime or CI-logic change.

- Version-update interval **weekly → monthly** on every ecosystem. Dependabot **security** updates are unaffected: they fire on GitHub advisory publication regardless of interval, and every tracked dependency here is dev / CI / build tooling (nothing ships to an end user's install).\n- Dev-dependency updates are **grouped per ecosystem**, so they arrive as one PR instead of several.\n- Where applicable, the **TypeScript major** (6 → 7 / tsgo) is held until the strict toolchain is deliberately migrated — stopping the recurring reopen churn.