### PR TITLE
chore: Dependabot auto-merge + Tier 2/3 config polish

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,18 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 5
     groups:
       actions:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      actions-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   - package-ecosystem: pip
@@ -16,8 +26,19 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 5
     groups:
       python-dev:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      pip-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   - package-ecosystem: npm
@@ -26,11 +47,20 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 5
     groups:
       card-deps:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      npm-security:
+        applies-to: security-updates
         patterns: ["*"]
     ignore:
-      # TypeScript 7 (tsgo/native compiler) — hold until the strict-mode
-      # toolchain is deliberately migrated. Revisit; don't auto-bump.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,13 +14,15 @@ on:
     - cron: "30 5 * * *"
   workflow_dispatch: {}
 
-# Declaring permissions restricts the token to exactly these scopes, so the
-# checks/statuses read scopes MUST be listed or `gh pr checks` sees nothing.
+# Declaring permissions restricts the token to exactly these scopes. gh pr checks
+# reads statusCheckRollup, whose checkSuite.workflowRun field needs actions:read —
+# without it the query 403s and every PR is skipped as "no CI checks".
 permissions:
   contents: write
   pull-requests: write
   checks: read
   statuses: read
+  actions: read
 
 concurrency:
   group: dependabot-auto-merge

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,57 @@
+name: Dependabot auto-merge
+
+# Auto-merges grouped MINOR/PATCH Dependabot PRs once every CI check on the PR
+# head is green. Majors are split out of the version groups (see dependabot.yml)
+# and arrive as individual PRs for manual review — never auto-merged. Security
+# updates use separate group names and are also left for manual review.
+# Runs daily (and on demand); merges within a day of CI passing. Works without
+# branch protection or native auto-merge, so it behaves identically on public
+# and private (free) repositories.
+
+on:
+  schedule:
+    - cron: "30 5 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-auto-merge
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge green grouped Dependabot PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          gh pr list --repo "$REPO" --author "app/dependabot" --state open \
+            --json number,title,mergeable > prs.json
+          total=$(jq length prs.json)
+          echo "Open Dependabot PRs: $total"
+          for i in $(seq 0 $((total - 1))); do
+            num=$(jq -r ".[$i].number" prs.json)
+            title=$(jq -r ".[$i].title" prs.json)
+            mergeable=$(jq -r ".[$i].mergeable" prs.json)
+            if ! printf '%s' "$title" | grep -qiE 'bump the (python-dev|card-deps|actions) group'; then
+              echo "- skip #$num (not an auto-merge group): $title"; continue
+            fi
+            if [ "$mergeable" != "MERGEABLE" ]; then
+              echo "- skip #$num (mergeable=$mergeable)"; continue
+            fi
+            buckets=$(gh pr checks "$num" --repo "$REPO" --json bucket --jq '.[].bucket' 2>/dev/null || true)
+            if [ -z "$buckets" ]; then
+              echo "- skip #$num (no CI checks reported)"; continue
+            fi
+            if printf '%s\n' "$buckets" | grep -qvE '^(pass|skipping)$'; then
+              echo "- skip #$num (CI not all green: $(printf '%s' "$buckets" | tr '\n' ',' ))"; continue
+            fi
+            echo "merging #$num: $title"
+            gh pr merge "$num" --repo "$REPO" --squash --delete-branch || echo "  ! merge failed for #$num"
+          done

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,9 +14,13 @@ on:
     - cron: "30 5 * * *"
   workflow_dispatch: {}
 
+# Declaring permissions restricts the token to exactly these scopes, so the
+# checks/statuses read scopes MUST be listed or `gh pr checks` sees nothing.
 permissions:
   contents: write
   pull-requests: write
+  checks: read
+  statuses: read
 
 concurrency:
   group: dependabot-auto-merge

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,12 +1,13 @@
 name: Dependabot auto-merge
 
 # Auto-merges grouped MINOR/PATCH Dependabot PRs once every CI check on the PR
-# head is green. Majors are split out of the version groups (see dependabot.yml)
-# and arrive as individual PRs for manual review — never auto-merged. Security
-# updates use separate group names and are also left for manual review.
-# Runs daily (and on demand); merges within a day of CI passing. Works without
-# branch protection or native auto-merge, so it behaves identically on public
-# and private (free) repositories.
+# head is green. Grouped version updates use branch names of the form
+# dependabot/<eco>/<dir>/<group-name>-<hash>; majors are split out of the groups
+# (see dependabot.yml update-types) into individual PRs, and security updates use
+# separate *-security groups — neither matches, so both get manual review.
+# Runs daily (and on demand); merges within a day of CI passing. Script-based (no
+# branch protection / native auto-merge) so it behaves identically on public and
+# private (free) repositories.
 
 on:
   schedule:
@@ -32,15 +33,19 @@ jobs:
         run: |
           set -uo pipefail
           gh pr list --repo "$REPO" --author "app/dependabot" --state open \
-            --json number,title,mergeable > prs.json
+            --json number,title,mergeable,headRefName > prs.json
           total=$(jq length prs.json)
           echo "Open Dependabot PRs: $total"
           for i in $(seq 0 $((total - 1))); do
             num=$(jq -r ".[$i].number" prs.json)
             title=$(jq -r ".[$i].title" prs.json)
+            branch=$(jq -r ".[$i].headRefName" prs.json)
             mergeable=$(jq -r ".[$i].mergeable" prs.json)
-            if ! printf '%s' "$title" | grep -qiE 'bump the (python-dev|card-deps|actions) group'; then
-              echo "- skip #$num (not an auto-merge group): $title"; continue
+            # Only version-update GROUP branches (python-dev / card-deps / actions),
+            # which by config carry minor/patch only. Majors (individual PRs) and
+            # security updates (*-security groups) don't match -> manual review.
+            if ! printf '%s' "$branch" | grep -qE 'dependabot/.+/(python-dev|card-deps|actions)-[0-9a-f]{6,}$'; then
+              echo "- skip #$num (not a version-group branch): $branch"; continue
             fi
             if [ "$mergeable" != "MERGEABLE" ]; then
               echo "- skip #$num (mergeable=$mergeable)"; continue


### PR DESCRIPTION
Uniform Dependabot best-practice pass across the portfolio.

**Config (`.github/dependabot.yml`)**
- `commit-message.prefix: chore` + `include: scope` → consistent `chore(deps):` / `chore(deps-dev):` subjects.
- Version groups restricted to `update-types: [minor, patch]` — **majors split into individual PRs** for manual review (incl. GitHub Actions v6→v7).
- `cooldown.default-days: 5` — skips versions released in the last 5 days.
- Separate `*-security` groups (`applies-to: security-updates`) batch any security fix into one PR (still reviewed by hand).

**Auto-merge (`.github/workflows/dependabot-auto-merge.yml`)**
- Scheduled daily; merges a grouped **minor/patch** Dependabot PR only when **every CI check on it is green**.
- Majors / security / conflicting / no-CI PRs are never auto-merged. Script-based (no branch protection) so it behaves identically on public and private repos.

Config + self-contained workflow; no runtime or CI-logic change.