### PR TITLE
fix: pin ruff (stop nightly CI breakage)

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,7 +11,7 @@ pytest-cov>=7.1.0,<8
 # floor here either matches PHACC (redundant) or contradicts it (unresolvable).
 # Let PHACC's transitive pin govern; dependabot bumps of syrupy can't apply.
 mypy>=2.3.0,<3
-ruff>=0.15.22,<1
+ruff==0.15.22
 # Floors track PHACC 0.13.331's hard pins (pytest-cov==7.1.0,
 # syrupy==5.1.0, pytest-asyncio==1.3.0). PHACC ≥0.13.317 wraps HA core
 # 2026.5+ and requires Python ≥3.14, so the CI workflow bumped to 3.14


### PR DESCRIPTION
**Root cause:** `requirements_test.txt` pins `ruff>=0.15.18,<1` — an unpinned range. The nightly `validate.yml` (`cron: 0 0 * * *`) resolved the newly-released **ruff 0.16.0**, which enabled new rules (UP041/I001/SIM102/RUF100/BLE001) and turned CI red on `main` with no code change. This is the floating-linter anti-pattern.

**Fix:** pin `ruff==0.15.22` (verified `All checks passed!` on main). Ruff upgrades now arrive as **Dependabot PRs** you review — where new rules are adopted deliberately — instead of breaking nightly CI unannounced.

Adopting ruff 0.16.0's newer rules (some flag legitimately-improvable code, e.g. `asyncio.TimeoutError`→`TimeoutError`) can then be a deliberate follow-up PR.