### PR TITLE
fix: pin mypy exact (stop floating-linter CI breakage)

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,7 +10,7 @@ pytest-cov>=7.1.0,<8
 # syrupy floor intentionally omitted: PHACC pins syrupy with `==`, so any
 # floor here either matches PHACC (redundant) or contradicts it (unresolvable).
 # Let PHACC's transitive pin govern; dependabot bumps of syrupy can't apply.
-mypy>=2.3.0,<3
+mypy==2.3.0
 ruff==0.15.22
 # Floors track PHACC 0.13.331's hard pins (pytest-cov==7.1.0,
 # syrupy==5.1.0, pytest-asyncio==1.3.0). PHACC ≥0.13.317 wraps HA core


### PR DESCRIPTION
Pins `mypy` exact (== not >=) so a new mypy release can't float into CI and break it on a schedule — the same failure mode ruff 0.16.0 caused. Pinned to the current-good version (verified in the last green run). mypy upgrades now arrive as reviewable Dependabot PRs whose CI shows any new findings.