### PR TITLE
ci: bump Node 20 (EOL) → 24 (Active LTS)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -120,7 +120,7 @@ jobs:
           fi
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
       - name: Install card deps
         run: npm ci


### PR DESCRIPTION
Node 20 reached **end-of-life 2026-04-30**; Node 24 is the current **Active LTS** (supported to April 2028). Card build verified green locally on Node 24 (`npm ci` + `tsc --noEmit` + rollup build + vitest, on both the newest and oldest card toolchains in the portfolio).