### PR TITLE
chore(deps): add the pre-commit Dependabot ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,3 +64,39 @@ updates:
     ignore:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: pre-commit
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"          # no prefix-development — unsupported here
+      include: "scope"
+    cooldown:
+      default-days: 5
+    groups:
+      pre-commit:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      pre-commit-security:
+        applies-to: security-updates
+        patterns: ["*"]
+    ignore:
+      # The ruff and mypy hook revs are manually kept equal to the `==`
+      # pins in requirements_test.txt (see .pre-commit-config.yaml).
+      # Letting Dependabot float them here would desync the local gate
+      # from CI — precisely what the exact pins exist to prevent. Bump
+      # these two by hand, in the same commit as the pin.
+      - dependency-name: "https://github.com/astral-sh/ruff-pre-commit"
+      - dependency-name: "https://github.com/pre-commit/mirrors-mypy"
+      # The mypy hook's `additional_dependencies` are parsed by
+      # Dependabot as dependencies in their own right (verified against
+      # dependabot-core's pre_commit file_parser). They are deliberately
+      # unpinned -- the hook only needs the type stubs importable, and
+      # the real HA version is governed by PHACC in requirements_test.
+      # Ignore them so Dependabot can't introduce a pin here.
+      - dependency-name: "homeassistant"
+      - dependency-name: "voluptuous"


### PR DESCRIPTION
## What

Adds a fourth Dependabot ecosystem, `pre-commit`, to `.github/dependabot.yml`. One file, config only — no code, no dependency versions change.

## Why this goes to `main` on its own

Dependabot reads `.github/dependabot.yml` from the **default branch**. The block already exists on `dev`, where it does nothing. Manifests are still scanned on `dev` via `target-branch: dev`, so this is the only file that has to reach `main` for the ecosystem to start working — the rest of the `dev` backlog can wait for a real release.

Without this ecosystem, nothing tracks `.pre-commit-config.yaml` `rev:` pins at all. A 2026-07 portfolio audit found four of five repos still on `ruff-pre-commit v0.8.0` — a 2024-era formatter — while CI ran a 2026 pin. Re-syncing reformatted 15–28 files per repo.

## The ignore list

| Ignored | Reason |
|---|---|
| `ruff-pre-commit`, `mirrors-mypy` | Revs are hand-synced to the `==` pins in `requirements_test.txt`. Letting Dependabot float them here would desync the local gate from the ruleset that decides green-on-main. |
| `homeassistant`, `voluptuous` | Dependabot parses a hook's `additional_dependencies` as dependencies in their own right — ignoring the hook repo does **not** cover them. Both are deliberately unpinned. |

## Verification

Confirmed against a live Dependabot updater run on the sibling private repo (whose default branch *is* `dev`, so it took effect immediately):

- all four `ignore-conditions` parsed
- `All versions of https://github.com/astral-sh/ruff-pre-commit ignored, no update allowed` — the repo-URL name format is correct
- discovered exactly the three hook repos; `pre-commit-hooks v6.0.0` → "no update needed"

## Risk

None to the build. No workflow, source, or dependency version is touched.
