### PR TITLE
test: catch HA deprecations on every test, in both message shapes

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,7 @@ strict_markers = true
 addopts = --cov --cov-fail-under=90
 markers =
     real_domain_cooldown: keep the real DOMAIN_COOLDOWN_SECONDS instead of zeroing it (see tests/conftest.py)
+    allow_deprecated_ha_api: test intentionally exercises a deprecated HA API
 # Turn DeprecationWarning into a test failure. What this actually
 # catches: deprecated *library* calls (aiohttp, PHACC, HA helpers)
 # reached through our own code paths. That is worth having.
@@ -25,8 +26,8 @@ markers =
 # What it does NOT catch: HA integration-API deprecations. HA reports
 # those via `frame.report_usage` -> `_LOGGER.warning`
 # (homeassistant/helpers/frame.py:393), never `warnings.warn`. The
-# `test_setup_uses_no_deprecated_ha_api` caplog assertion covers that
-# channel instead.
+# `no_deprecated_ha_api` autouse fixture in tests/conftest.py covers that
+# channel instead — on every test, and for both of HA's message shapes.
 #
 # Two known limits:
 #   * A third-party deprecation outside the three ignore scopes below

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -388,3 +388,59 @@ def mock_fetch(monitor_fixture):
         ),
     ):
         yield m
+
+
+@pytest.fixture(autouse=True)
+def no_deprecated_ha_api(
+    request: pytest.FixtureRequest, caplog: pytest.LogCaptureFixture
+) -> Generator[None]:
+    """Fail any test that trips Home Assistant's deprecation channel.
+
+    `frame.report_usage` logs through `_LOGGER.warning` and never calls
+    `warnings.warn`, so `pytest.ini`'s `error::DeprecationWarning` filter
+    cannot see it. This is that filter's counterpart for HA's own channel,
+    and it runs on every test rather than on one.
+
+    HA emits two message shapes and picks the severity tier from whichever
+    applies (`homeassistant/helpers/frame.py`):
+
+    - "Detected that custom integration '<x>' ..." when the stack walk finds
+      our integration. Governed by `custom_integration_behavior`, the most
+      lenient tier — it is still LOG long after core has moved on.
+    - "Detected code that ..." when HA cannot attribute the call to any
+      integration, which is exactly what happens for a call made from a
+      *test* file. Governed by `core_behavior`, the strictest tier, and so
+      the first to turn a warning into a `RuntimeError`.
+
+    Watching only the first shape is what let `device_registry.async_get_device`
+    reach a hard CI failure on 2026-08-29. The deprecation had been logging
+    since HA 2026.7, but only ever from the test file, so the old single-test
+    tripwire never saw it. Catching both shapes means a deprecation fails the
+    build while it is still a warning in our tier, which makes the eventual
+    flip to ERROR a no-op.
+
+    Records are read per phase via `get_records`, not from `caplog.text`:
+    pytest installs a fresh handler for each of setup/call/teardown, so by
+    the time this finaliser runs `caplog.text` holds teardown records only
+    and would miss everything the test body logged.
+
+    Opt out for a test that asserts deprecation behaviour on purpose:
+
+        @pytest.mark.allow_deprecated_ha_api
+    """
+    yield
+    if request.node.get_closest_marker("allow_deprecated_ha_api"):
+        return
+    hits = [
+        message
+        for phase in ("setup", "call")
+        for record in caplog.get_records(phase)
+        if (message := record.getMessage()).startswith(
+            ("Detected that ", "Detected code that ")
+        )
+    ]
+    if hits:
+        pytest.fail(
+            "Home Assistant reported deprecated API use:\n  " + "\n  ".join(hits),
+            pytrace=False,
+        )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -161,8 +161,16 @@ async def test_setup_uses_no_deprecated_ha_api(
 
     `frame.report_usage` logs through `_LOGGER.warning`
     (homeassistant/helpers/frame.py:393) and never calls `warnings.warn`,
-    so pytest.ini's `error::DeprecationWarning` cannot see it. This is the
-    check that covers that channel.
+    so pytest.ini's `error::DeprecationWarning` cannot see it.
+
+    Superseded as a *net* on 2026-08-29 by the `no_deprecated_ha_api`
+    autouse fixture in conftest.py, which makes this assertion after every
+    test and matches both of HA's message shapes — where this one sees only
+    "Detected that custom integration ...", the lenient tier that misses any
+    deprecated call made from a test file. Kept deliberately: it exercises a
+    full entry setup, and a named test states the intent where an autouse
+    fixture is easy to miss. The fixture is the real coverage; this is a
+    readable anchor for it.
     """
     caplog.set_level(logging.WARNING)
     entry = _make_entry()


### PR DESCRIPTION
## Summary
Home Assistant deprecations now fail the build while they are still warnings, instead of surfacing as a hard CI failure the day HA promotes one to an error. Test-only: no user-facing change, and deliberately no version bump.

## Breaking changes
_None._

## Changed
- `tests/conftest.py` gains a `no_deprecated_ha_api` autouse fixture that fails any test tripping HA's deprecation channel, matching **both** message shapes HA emits.
- `pytest.ini` registers `allow_deprecated_ha_api` as the opt-out marker (required, since `strict_markers = true`).
- `test_setup_uses_no_deprecated_ha_api` is kept as a readable anchor; its docstring now records that the fixture is the load-bearing check.

## Why
The previous single-test tripwire asserted only on `"Detected that custom integration ..."`. HA's `helpers/frame.py` emits two shapes and picks the severity tier from whichever applies:

- `"Detected that ... integration"` — the stack walk found our integration. Governed by `custom_integration_behavior`, the most lenient tier.
- `"Detected code that ..."` — HA could not attribute the call to any integration, which is what happens for a call made from a *test* file. Governed by `core_behavior`, the strictest tier, and the first to turn a warning into a `RuntimeError`.

So test code was held to a stricter standard than shipped code while having no tripwire coverage at all. That is how `device_registry.async_get_device` reached a hard CI failure on 2026-08-29: it had been logging since HA 2026.7, but only ever from the test file, so nothing saw it.

Catching both shapes on every test means a deprecation fails the build during its LOG phase, which makes the eventual flip to ERROR a no-op.

## Compatibility
Unchanged — no change to the Home Assistant or HACS minimum.

## Test plan
- Full gate: `pytest` (coverage floor met), `mypy --strict`, `ruff check`, `ruff format --check`. No card-side file changed, so the bundle is untouched.
- Mechanism verified with a throwaway probe before rollout: the fixture must read `caplog.get_records("setup"/"call")`, not `caplog.text` — pytest installs a fresh log handler per phase, so a finaliser reading `.text` sees teardown records only and would silently catch nothing.
- A second probe confirmed the fixture is live after rollout (catches both shapes; the opt-out marker passes).
- CI green on `dev`.

## Risk
None to users. Nothing under `custom_components/` or `src/` changed. Version deliberately not bumped — this ships with whatever release comes next.
