### PR TITLE
test: pin the clock in the serverTime-fallback staleness test

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from freezegun.api import FrozenDateTimeFactory
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
@@ -622,6 +623,9 @@ async def test_scan_interval_reflects_config(hass: HomeAssistant) -> None:
 # `serverTime` from the captured fixture. Every staleness assertion is
 # anchored on it rather than on wall-clock now, so these tests keep meaning
 # the same thing in 2027 as they did the evening the outage was captured.
+# The one test that exercises the `dt_util.utcnow()` fallback can't take the
+# anchor as an argument, so it pins the clock here instead — same invariant,
+# applied through `freezer` rather than through the parameter.
 STALE_FIXTURE_SERVER_TIME = "2026-08-29T19:11:47.000+0200"
 
 
@@ -731,13 +735,24 @@ def test_unjudgeable_timestamp_keeps_the_departure(planned) -> None:
     assert len(result.departures) == 1
 
 
-def test_missing_server_time_falls_back_to_local_clock(stale_metro_fixture) -> None:
+def test_missing_server_time_falls_back_to_local_clock(
+    stale_metro_fixture, freezer: FrozenDateTimeFactory
+) -> None:
     """No serverTime in the payload still catches a 60-hour-old record.
 
     The fallback matters because `serverTime` lives in the envelope, not the
     monitor block — a batch slice or a truncated response can arrive without
     it, and that must not disable the plausibility check entirely.
+
+    Pinning the clock to the capture instant is what the assertion means:
+    in production the response was just fetched, so our clock stands in for
+    the `serverTime` the envelope didn't carry. On the real clock the test
+    quietly changes subject as the fixture ages — once every row is past the
+    three-hour floor it stops distinguishing the frozen U1 rows from the
+    healthy 48A ones and starts asserting that everything is dropped.
     """
+    freezer.move_to(STALE_FIXTURE_SERVER_TIME)
+
     result = _parse_monitor_body(stale_metro_fixture, None, None)
 
     assert result.stale_dropped == 2


### PR DESCRIPTION
## Summary
Fixed a time-dependent test that started failing on the nightly schedule with no code change behind it. Internal only — no user-visible behaviour changes and no version bump, so this merge is not a release.

## Breaking changes
_None._

## Fixed
- Nothing user-facing. `_parse_monitor_body`'s staleness filter is correct as written and is unchanged by this PR.

<details><summary>Internal changes</summary>

`test_missing_server_time_falls_back_to_local_clock` passes `server_time=None` deliberately, so the parser anchors its staleness floor on `dt_util.utcnow()` instead of the payload. Against the real clock that assertion drifted: the checked-in fixture was captured at 2026-08-29T19:11+0200, and once wall-clock now passed capture plus `STALE_DEPARTURE_MAX_AGE` (3 h), the healthy 48A rows aged out alongside the frozen U1 ones. The test stopped separating a frozen feed from a live one and started asserting that the whole payload is stale — a silent change of subject that only surfaced when the count moved, on the first scheduled run after the crossover (2026-08-30 04:07 UTC, `assert 9 == 2`).

The clock is now pinned to the fixture's own capture instant via `freezer`. That models the production case the test describes: a response that just arrived, its envelope missing `serverTime`, the local clock standing in for it. It also restores the invariant the surrounding block already documents — every staleness assertion anchored on the fixture rather than on wall-clock now — which the other three tests hold to by passing the anchor as an argument.

Checked while diagnosing, no changes needed: `serverTime` is propagated to every member coordinator on the 200 path and replayed from the cached body on 304, so the `None` case is a genuine edge rather than a bug the fallback was hiding; and `coordinator.py:456` is the only wall-clock read in the parse path.

</details>

## Compatibility
- Home Assistant: ≥ 2025.1.0
- HACS: unchanged
- Version stays 1.7.8 across `manifest.json` and all three card constants.

## Test plan
- Full verification gate green: 215 passed (coverage 91.11 %), `mypy --strict` clean, `ruff check` and `ruff format --check` clean, `tsc --noEmit` clean, 3.12 floor `compileall` clean, `npm run build` produced no bundle drift.
- Wall-clock independence proven, not assumed: the suite was re-run with the session clock faked to 2027-06-01 and both staleness tests passed. A control run with the pin removed under that same 2027 clock reproduced CI's exact `assert 9 == 2`.
- Swept the rest of the suite for the same exposure. The only other hardcoded past `timePlanned` sits on a record with no `countdown`, which the parser drops before the staleness check runs, so it is clock-independent.

## Risk
Low. One test file; no production code, no card bundle, no dependency change.